### PR TITLE
URL upload artist tile fix

### DIFF
--- a/api/api/routes/jobs_runtime.py
+++ b/api/api/routes/jobs_runtime.py
@@ -545,9 +545,11 @@ def download_source_audio(
     job = get_job(DB_PATH, job_id)
     if job and job.source_provider != "upload" and (not job.track_title or not job.track_title.strip()):
         if isinstance(info, dict):
-            info_title = info.get("title")
+            info_title = info.get("track") or info.get("title")
+            info_artist = info.get("artist") or info.get("uploader") or info.get("creator")
             if isinstance(info_title, str) and info_title.strip():
-                update_job_track_metadata(DB_PATH, job_id, sanitize_title(info_title), "")
+                _artist = info_artist if isinstance(info_artist, str) else ""
+                update_job_track_metadata(DB_PATH, job_id, sanitize_title(info_title), _artist.strip())
 
     input_path = None
     if isinstance(info, dict):


### PR DESCRIPTION
Fixes an issue where using URL upload with the new providers, song titles don't correctly show the artist's correctly.

e.g.. using a Bandcamp would show up as "Ben Prunty Last Stand" and not "Last Stand — Ben Prunty"

Soundcloud uploads has the artist absent from the song title.