### PR TITLE
jump timing fix

### DIFF
--- a/pwa/src/app/routes/Listen.tsx
+++ b/pwa/src/app/routes/Listen.tsx
@@ -950,8 +950,8 @@ export function Listen({ isActive = true }: { isActive?: boolean }) {
     } else {
       engine.syncToPlaybackPosition();
     }
-    engine.startJukebox(resetSession);
     engine.play();
+    engine.startJukebox(resetSession);
     lastPlayStampRef.current = performance.now();
     setIsRunning(true);
     setIsPaused(false);
@@ -999,8 +999,8 @@ export function Listen({ isActive = true }: { isActive?: boolean }) {
     vizControllerRef.current?.update(index, true, null);
 
     if (!isRunningRef.current) {
-      engine.startJukebox(false);
       engine.play();
+      engine.startJukebox(false);
       lastPlayStampRef.current = performance.now();
       setIsRunning(true);
       setIsPaused(false);

--- a/pwa/src/shared/jukebox/audio/BufferedAudioPlayer.test.ts
+++ b/pwa/src/shared/jukebox/audio/BufferedAudioPlayer.test.ts
@@ -251,11 +251,55 @@ describe("BufferedAudioPlayer", () => {
     await player.loadBuffer({ duration: 10 } as AudioBuffer);
     player.play();
     expect(context.createdSources).toHaveLength(1);
-    player.scheduleJump(2, 0);
+    player.scheduleJump(2, 1);
     const firstPending = context.createdSources[1];
     expect(firstPending).toBeDefined();
-    player.scheduleJump(3, 0);
+    player.scheduleJump(3, 1);
     expect(firstPending?.stop).toHaveBeenCalled();
     expect(firstPending?.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules jumps from the current source cursor", async () => {
+    const context = new MockAudioContext();
+    context.currentTime = 10;
+    const player = new BufferedAudioPlayer(context as unknown as AudioContext);
+    await player.loadBuffer({ duration: 20 } as AudioBuffer);
+    player.play();
+    context.currentTime = 10.25;
+
+    player.scheduleJump(2, 1);
+
+    expect(context.createdSources).toHaveLength(2);
+    expect(context.createdSources[1]?.start).toHaveBeenCalledWith(11, 2, 18);
+    expect(context.createdSources[0]?.stop).toHaveBeenCalledWith(11);
+  });
+
+  it("skips stale jumps that are already past the source boundary", async () => {
+    const context = new MockAudioContext();
+    context.currentTime = 1;
+    const player = new BufferedAudioPlayer(context as unknown as AudioContext);
+    await player.loadBuffer({ duration: 20 } as AudioBuffer);
+    player.play();
+    context.currentTime = 1.01;
+
+    player.scheduleJump(2, 0);
+
+    expect(context.createdSources).toHaveLength(1);
+    expect(context.createdSources[0]?.stop).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending scheduled jump", async () => {
+    const context = new MockAudioContext();
+    context.currentTime = 1;
+    const player = new BufferedAudioPlayer(context as unknown as AudioContext);
+    await player.loadBuffer({ duration: 20 } as AudioBuffer);
+    player.play();
+    player.scheduleJump(2, 1);
+    const pending = context.createdSources[1];
+
+    player.cancelScheduledJump();
+
+    expect(pending?.stop).toHaveBeenCalled();
+    expect(pending?.disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/pwa/src/shared/jukebox/audio/BufferedAudioPlayer.ts
+++ b/pwa/src/shared/jukebox/audio/BufferedAudioPlayer.ts
@@ -68,6 +68,7 @@ const AUDIO_MODE_SETTINGS: Record<JukeboxAudioMode, AudioModeSettings> = {
 
 const REVERB_SECONDS = 2.5;
 const PAN_STEP = 0.007;
+const MAX_LATE_JUMP_FRAMES = 8;
 
 export class BufferedAudioPlayer {
   private context: AudioContext;
@@ -258,11 +259,19 @@ export class BufferedAudioPlayer {
     return this.playbackRate;
   }
 
-  scheduleJump(targetTime: number, audioStart: number) {
+  scheduleJump(targetTime: number, sourceStartTime: number) {
     if (!this.buffer || !this.playing) {
       return;
     }
-    const startTime = audioStart === 0 ? this.context.currentTime : audioStart;
+    const currentSourceTime = this.getCurrentTime();
+    this.clearPendingSwap();
+    const lateBy = currentSourceTime - sourceStartTime;
+    const maxLateSeconds = MAX_LATE_JUMP_FRAMES / this.context.sampleRate;
+    if (lateBy > maxLateSeconds) {
+      return;
+    }
+    const sourceLead = Math.max(0, sourceStartTime - currentSourceTime);
+    const startTime = this.context.currentTime + sourceLead / this.playbackRate;
     const source = this.context.createBufferSource();
     source.buffer = this.buffer;
     source.playbackRate.value = this.playbackRate;
@@ -288,10 +297,13 @@ export class BufferedAudioPlayer {
         // no-op
       }
     }
-    this.clearPendingSwap();
     this.pendingSource = source;
     this.pendingStartAt = startTime - targetTime / this.playbackRate;
     this.pendingSwapAt = startTime;
+  }
+
+  cancelScheduledJump() {
+    this.clearPendingSwap();
   }
 
   private stopSource() {

--- a/pwa/src/shared/jukebox/engine/JukeboxEngine.test.ts
+++ b/pwa/src/shared/jukebox/engine/JukeboxEngine.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { JukeboxEngine, type JukeboxPlayer } from "./JukeboxEngine";
+import type {
+  Edge,
+  JukeboxGraphState,
+  QuantumBase,
+  TrackAnalysis,
+} from "./types";
+
+function makeBeat(which: number): QuantumBase {
+  return {
+    start: which,
+    duration: 1,
+    which,
+    prev: null,
+    next: null,
+    overlappingSegments: [],
+    neighbors: [],
+    allNeighbors: [],
+  };
+}
+
+function linkBeats(beats: QuantumBase[]) {
+  beats.forEach((beat, idx) => {
+    beat.prev = idx > 0 ? beats[idx - 1] : null;
+    beat.next = idx < beats.length - 1 ? beats[idx + 1] : null;
+  });
+}
+
+function makeAnalysis(beats: QuantumBase[]): TrackAnalysis {
+  return {
+    sections: [],
+    bars: [],
+    beats,
+    tatums: [],
+    segments: [],
+    track: {},
+  };
+}
+
+function makePlayer(overrides: Partial<JukeboxPlayer> = {}): JukeboxPlayer {
+  return {
+    play: vi.fn(),
+    pause: vi.fn(),
+    stop: vi.fn(),
+    seek: vi.fn(),
+    scheduleJump: vi.fn(),
+    cancelScheduledJump: vi.fn(),
+    getCurrentTime: () => 0,
+    getAudioTime: () => 0,
+    getPlaybackRate: () => 1,
+    isPlaying: () => true,
+    ...overrides,
+  };
+}
+
+function makeGraph(beats: QuantumBase[], edge: Edge | null): JukeboxGraphState {
+  return {
+    computedThreshold: 0,
+    currentThreshold: 0,
+    lastBranchPoint: edge?.src.which ?? 0,
+    totalBeats: beats.length,
+    longestReach: 0,
+    allEdges: edge ? [edge] : [],
+  };
+}
+
+function installEngineState(
+  engine: JukeboxEngine,
+  beats: QuantumBase[],
+  graph: JukeboxGraphState,
+  currentBeatIndex: number,
+  nextAudioTime: number,
+) {
+  const engineAny = engine as unknown as {
+    analysis: TrackAnalysis;
+    graph: JukeboxGraphState;
+    beats: QuantumBase[];
+    currentBeatIndex: number;
+    nextAudioTime: number;
+    curRandomBranchChance: number;
+    advanceBeat: (audioTime: number) => void;
+    preparePendingAdvance: (audioTime: number) => void;
+  };
+  engineAny.analysis = makeAnalysis(beats);
+  engineAny.graph = graph;
+  engineAny.beats = beats;
+  engineAny.currentBeatIndex = currentBeatIndex;
+  engineAny.nextAudioTime = nextAudioTime;
+  engineAny.curRandomBranchChance = engine.getConfig().minRandomBranchChance;
+  return engineAny;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("PWA JukeboxEngine jump scheduling parity", () => {
+  it("schedules selected branches at the source beat boundary", () => {
+    const player = makePlayer();
+    const engine = new JukeboxEngine(player, { randomMode: "seeded", seed: 1 });
+    const beats = [0, 1, 2].map(makeBeat);
+    linkBeats(beats);
+    const edge: Edge = {
+      id: 0,
+      src: beats[1],
+      dest: beats[0],
+      distance: 10,
+      deleted: false,
+    };
+    beats[1].neighbors = [edge];
+    beats[1].allNeighbors = [edge];
+    const engineAny = installEngineState(
+      engine,
+      beats,
+      makeGraph(beats, edge),
+      0,
+      10.75,
+    );
+
+    engineAny.advanceBeat(engineAny.nextAudioTime);
+
+    expect(player.scheduleJump).toHaveBeenCalledTimes(1);
+    expect(player.scheduleJump).toHaveBeenCalledWith(0, 1);
+  });
+
+  it("uses the final beat end as the source boundary when wrapping", () => {
+    const player = makePlayer();
+    const engine = new JukeboxEngine(player, { randomMode: "seeded", seed: 2 });
+    const beats = [0, 1].map(makeBeat);
+    linkBeats(beats);
+    const engineAny = installEngineState(
+      engine,
+      beats,
+      makeGraph(beats, null),
+      1,
+      10.75,
+    );
+
+    engineAny.advanceBeat(engineAny.nextAudioTime);
+
+    expect(player.scheduleJump).toHaveBeenCalledTimes(1);
+    expect(player.scheduleJump).toHaveBeenCalledWith(0, 2);
+  });
+
+  it("fails closed when the first branch boundary is too close", () => {
+    const player = makePlayer({ getCurrentTime: () => 0.95 });
+    const engine = new JukeboxEngine(player, { randomMode: "seeded", seed: 1 });
+    const beats = [0, 1, 2].map(makeBeat);
+    linkBeats(beats);
+    const edge: Edge = {
+      id: 0,
+      src: beats[1],
+      dest: beats[0],
+      distance: 10,
+      deleted: false,
+    };
+    beats[1].neighbors = [edge];
+    beats[1].allNeighbors = [edge];
+    const engineAny = installEngineState(
+      engine,
+      beats,
+      makeGraph(beats, edge),
+      0,
+      10.05,
+    );
+
+    engineAny.advanceBeat(engineAny.nextAudioTime);
+
+    expect(engineAny.currentBeatIndex).toBe(1);
+    expect(player.scheduleJump).not.toHaveBeenCalled();
+  });
+
+  it("cancels a prepared source-position jump when syncing playback", () => {
+    let currentTime = 0.25;
+    const player = makePlayer({
+      getCurrentTime: () => currentTime,
+      getAudioTime: () => 10,
+    });
+    const engine = new JukeboxEngine(player, { randomMode: "seeded", seed: 1 });
+    const beats = [0, 1, 2].map(makeBeat);
+    linkBeats(beats);
+    const edge: Edge = {
+      id: 0,
+      src: beats[1],
+      dest: beats[0],
+      distance: 10,
+      deleted: false,
+    };
+    beats[1].neighbors = [edge];
+    beats[1].allNeighbors = [edge];
+    const engineAny = installEngineState(
+      engine,
+      beats,
+      makeGraph(beats, edge),
+      0,
+      10.75,
+    );
+    engineAny.preparePendingAdvance(engineAny.nextAudioTime);
+    expect(player.scheduleJump).toHaveBeenCalledTimes(1);
+
+    currentTime = 0.4;
+    engine.syncToPlaybackPosition();
+
+    expect(player.cancelScheduledJump).toHaveBeenCalledTimes(1);
+  });
+
+  it("resetStats clears per-source branch repeat history", () => {
+    const engine = new JukeboxEngine(makePlayer());
+    const engineAny = engine as unknown as {
+      branchState: { lastDestBySource: Map<number, number> | null };
+    };
+    engineAny.branchState.lastDestBySource = new Map([[4, 1]]);
+
+    engine.resetStats();
+
+    expect(engineAny.branchState.lastDestBySource).toBeNull();
+  });
+});

--- a/pwa/src/shared/jukebox/engine/JukeboxEngine.ts
+++ b/pwa/src/shared/jukebox/engine/JukeboxEngine.ts
@@ -5,7 +5,11 @@ import {
   backgroundClearTimeout,
   backgroundSetTimeout,
 } from "../background/backgroundTimer";
-import { getBestLastBranchNeighborIndex, selectNextBeatIndex } from "./selection";
+import {
+  BranchState,
+  getBestLastBranchNeighborIndex,
+  selectNextBeatIndex,
+} from "./selection";
 import {
   JukeboxConfig,
   JukeboxGraphState,
@@ -28,8 +32,18 @@ const DEFAULT_CONFIG: JukeboxConfig = {
 };
 
 const TICK_INTERVAL_MS = 50;
+const MIN_JUMP_SCHEDULE_LEAD_SECONDS = 0.08;
 
 type UpdateListener = (state: JukeboxState) => void;
+
+type PendingAdvance = {
+  boundaryAudioTime: number;
+  chosenIndex: number;
+  shouldJump: boolean;
+  targetTime: number | null;
+  jumpFromIndex: number | null;
+  sourceBoundaryTime: number | null;
+};
 
 export interface JukeboxEngineOptions {
   randomMode?: RandomMode;
@@ -42,7 +56,8 @@ export interface JukeboxPlayer {
   pause: () => void;
   stop: () => void;
   seek: (time: number) => void;
-  scheduleJump: (targetTime: number, audioStart: number) => void;
+  scheduleJump: (targetTime: number, sourceStartTime: number) => void;
+  cancelScheduledJump: () => void;
   getCurrentTime: () => number;
   getAudioTime: () => number;
   getPlaybackRate: () => number;
@@ -66,10 +81,14 @@ export class JukeboxEngine {
   private lastJumpFromIndex: number | null = null;
   private forceBranch = false;
   private bringItHomeMode = false;
+  private pendingAdvance: PendingAdvance | null = null;
   private deletedEdgeKeys = new Set<string>();
   private rng: () => number;
   private listener: UpdateListener | null = null;
-  private branchState = { curRandomBranchChance: 0 };
+  private branchState: BranchState = {
+    curRandomBranchChance: 0,
+    lastDestBySource: null,
+  };
 
   constructor(player: JukeboxPlayer, options: JukeboxEngineOptions = {}) {
     this.player = player;
@@ -94,9 +113,11 @@ export class JukeboxEngine {
     this.nextAudioTime = audioNow + beat.duration / playbackRate;
     this.curRandomBranchChance = this.config.minRandomBranchChance;
     this.branchState.curRandomBranchChance = this.curRandomBranchChance;
+    this.branchState.lastDestBySource = null;
     this.lastJumped = false;
     this.lastJumpTime = null;
     this.lastJumpFromIndex = null;
+    this.clearPendingAdvance(true);
   }
 
   loadAnalysis(data: unknown) {
@@ -125,6 +146,7 @@ export class JukeboxEngine {
     if (!this.analysis) {
       return;
     }
+    this.clearPendingAdvance(true);
     this.clearEdgeDeletionFlags();
     this.config.minLongBranch = Math.floor(this.analysis.beats.length / 5);
     this.graph = buildJumpGraph(this.analysis, this.config);
@@ -219,6 +241,7 @@ export class JukeboxEngine {
     this.lastJumped = false;
     this.lastJumpTime = null;
     this.lastJumpFromIndex = null;
+    this.clearPendingAdvance(true);
   }
 
   stopJukebox() {
@@ -241,6 +264,7 @@ export class JukeboxEngine {
 
   clearDeletedEdges() {
     this.deletedEdgeKeys.clear();
+    this.clearPendingAdvance(true);
     this.clearEdgeDeletionFlags();
   }
 
@@ -248,6 +272,7 @@ export class JukeboxEngine {
     const srcIndex = edge.src.which;
     const destIndex = edge.dest.which;
     this.deletedEdgeKeys.add(this.edgeKey(srcIndex, destIndex));
+    this.clearPendingAdvance(true);
     this.applyDeletedEdges();
   }
 
@@ -339,9 +364,11 @@ export class JukeboxEngine {
     this.beatsPlayed = 0;
     this.curRandomBranchChance = this.config.minRandomBranchChance;
     this.branchState.curRandomBranchChance = this.curRandomBranchChance;
+    this.branchState.lastDestBySource = null;
     this.lastJumped = false;
     this.lastJumpTime = null;
     this.lastJumpFromIndex = null;
+    this.clearPendingAdvance(true);
   }
 
   private tick() {
@@ -355,13 +382,17 @@ export class JukeboxEngine {
     }
 
     const audioTime = this.player.getAudioTime();
-    if (this.nextAudioTime === 0) {
+    if (this.currentBeatIndex < 0 && this.nextAudioTime === 0) {
+      this.initializeBeatClock(audioTime);
+    } else if (this.nextAudioTime === 0) {
       this.nextAudioTime = audioTime;
     }
 
     let guard = this.beats.length;
+    this.preparePendingAdvance(this.nextAudioTime);
     while (guard > 0 && audioTime >= this.nextAudioTime) {
       this.advanceBeat(this.nextAudioTime);
+      this.preparePendingAdvance(this.nextAudioTime);
       guard -= 1;
     }
     if (!this.ticking) {
@@ -382,29 +413,83 @@ export class JukeboxEngine {
     if (!this.analysis || !this.graph) {
       return;
     }
+    if (
+      this.currentBeatIndex >= 0 &&
+      this.bringItHomeMode &&
+      this.currentBeatIndex === this.beats.length - 1
+    ) {
+      this.ticking = false;
+      this.timerId = null;
+      this.nextAudioTime = Number.POSITIVE_INFINITY;
+      this.lastJumped = false;
+      this.lastJumpTime = null;
+      this.lastJumpFromIndex = null;
+      this.clearPendingAdvance(false);
+      return;
+    }
+    const advance =
+      this.pendingAdvance?.boundaryAudioTime === audioTime
+        ? this.pendingAdvance
+        : this.createPendingAdvance(audioTime, true);
+    if (!advance) {
+      return;
+    }
+    this.pendingAdvance = null;
+    this.commitAdvance(advance);
+  }
+
+  private preparePendingAdvance(boundaryAudioTime: number) {
+    if (this.currentBeatIndex < 0 || boundaryAudioTime <= 0) {
+      return;
+    }
+    if (
+      this.bringItHomeMode &&
+      this.currentBeatIndex === this.beats.length - 1
+    ) {
+      return;
+    }
+    if (this.pendingAdvance?.boundaryAudioTime === boundaryAudioTime) {
+      return;
+    }
+    this.pendingAdvance = this.createPendingAdvance(boundaryAudioTime, true);
+  }
+
+  private createPendingAdvance(
+    boundaryAudioTime: number,
+    scheduleJump: boolean,
+  ): PendingAdvance | null {
+    if (!this.analysis || !this.graph) {
+      return null;
+    }
     const currentIndex = this.currentBeatIndex;
     const beatsCount = this.beats.length;
     let chosenIndex = 0;
     let shouldJump = false;
     let jumpFromIndex: number | null = null;
+    let sourceBoundaryTime: number | null = null;
 
     if (currentIndex >= 0) {
-      const isFinalBeat = currentIndex === beatsCount - 1;
-      if (this.bringItHomeMode && isFinalBeat) {
-        this.ticking = false;
-        this.timerId = null;
-        this.nextAudioTime = Number.POSITIVE_INFINITY;
-        this.lastJumped = false;
-        this.lastJumpTime = null;
-        this.lastJumpFromIndex = null;
-        return;
-      }
       const nextIndex = currentIndex + 1;
       const wrappedIndex = nextIndex >= beatsCount ? 0 : nextIndex;
       if (this.bringItHomeMode) {
         chosenIndex = wrappedIndex;
       } else {
         const seed = this.beats[wrappedIndex];
+        const wrappedToStart =
+          wrappedIndex === 0 && currentIndex === beatsCount - 1;
+        sourceBoundaryTime = wrappedToStart
+          ? this.beats[currentIndex].start + this.beats[currentIndex].duration
+          : seed.start;
+        if (!wrappedToStart && !this.hasJumpScheduleLead(sourceBoundaryTime)) {
+          return {
+            boundaryAudioTime,
+            chosenIndex: wrappedIndex,
+            shouldJump: false,
+            targetTime: null,
+            jumpFromIndex: null,
+            sourceBoundaryTime: null,
+          };
+        }
         this.branchState.curRandomBranchChance = this.curRandomBranchChance;
         const selection = selectNextBeatIndex(
           seed,
@@ -417,8 +502,6 @@ export class JukeboxEngine {
         this.curRandomBranchChance = this.branchState.curRandomBranchChance;
         shouldJump = selection.jumped;
         chosenIndex = shouldJump ? selection.index : wrappedIndex;
-        const wrappedToStart =
-          wrappedIndex === 0 && currentIndex === beatsCount - 1;
         if (wrappedToStart) {
           shouldJump = true;
         }
@@ -431,23 +514,72 @@ export class JukeboxEngine {
     }
 
     const targetBeat = this.beats[chosenIndex];
-    if (shouldJump) {
-      const targetTime = targetBeat.start;
-      this.player.scheduleJump(targetTime, audioTime);
+    if (!targetBeat) {
+      return null;
+    }
+    const targetTime = shouldJump ? targetBeat.start : null;
+    if (scheduleJump && targetTime !== null && sourceBoundaryTime !== null) {
+      this.player.scheduleJump(targetTime, sourceBoundaryTime);
+    }
+    return {
+      boundaryAudioTime,
+      chosenIndex,
+      shouldJump,
+      targetTime,
+      jumpFromIndex,
+      sourceBoundaryTime,
+    };
+  }
+
+  private commitAdvance(advance: PendingAdvance) {
+    const targetBeat = this.beats[advance.chosenIndex];
+    if (advance.shouldJump) {
       this.lastJumped = true;
-      this.lastJumpTime = targetTime;
-      this.lastJumpFromIndex = jumpFromIndex;
+      this.lastJumpTime = advance.targetTime;
+      this.lastJumpFromIndex = advance.jumpFromIndex;
     } else {
       this.lastJumped = false;
       this.lastJumpTime = null;
       this.lastJumpFromIndex = null;
     }
 
-    this.currentBeatIndex = chosenIndex;
-    const startTime = this.nextAudioTime === 0 ? audioTime : this.nextAudioTime;
+    this.currentBeatIndex = advance.chosenIndex;
     const playbackRate = this.getPlaybackRate();
-    this.nextAudioTime = startTime + targetBeat.duration / playbackRate;
+    this.nextAudioTime =
+      advance.boundaryAudioTime + targetBeat.duration / playbackRate;
     this.beatsPlayed += 1;
+  }
+
+  private initializeBeatClock(audioTime: number) {
+    const trackTime = this.player.getCurrentTime();
+    const beatIndex = this.findBeatIndexByTime(trackTime);
+    if (beatIndex < 0 || beatIndex >= this.beats.length) {
+      this.nextAudioTime = audioTime;
+      return;
+    }
+    const beat = this.beats[beatIndex];
+    const elapsedInBeat = Math.max(
+      0,
+      Math.min(beat.duration, trackTime - beat.start),
+    );
+    const remainingInBeat = Math.max(0, beat.duration - elapsedInBeat);
+    this.currentBeatIndex = beatIndex;
+    this.beatsPlayed = Math.max(this.beatsPlayed, beatIndex + 1);
+    this.nextAudioTime = audioTime + remainingInBeat / this.getPlaybackRate();
+  }
+
+  private clearPendingAdvance(cancelScheduledJump: boolean) {
+    if (cancelScheduledJump && this.pendingAdvance?.targetTime !== null) {
+      this.player.cancelScheduledJump();
+    }
+    this.pendingAdvance = null;
+  }
+
+  private hasJumpScheduleLead(sourceBoundaryTime: number): boolean {
+    return (
+      sourceBoundaryTime - this.player.getCurrentTime() >=
+      MIN_JUMP_SCHEDULE_LEAD_SECONDS
+    );
   }
 
   private getPlaybackRate(): number {

--- a/pwa/src/shared/jukebox/engine/deleteResetParityFixtures.test.ts
+++ b/pwa/src/shared/jukebox/engine/deleteResetParityFixtures.test.ts
@@ -65,6 +65,7 @@ function makePlayer(): JukeboxPlayer {
     stop: vi.fn(),
     seek: vi.fn(),
     scheduleJump: vi.fn(),
+    cancelScheduledJump: vi.fn(),
     getCurrentTime: () => 0,
     getAudioTime: () => 0,
     getPlaybackRate: () => 1,

--- a/pwa/src/shared/jukebox/engine/selection.test.ts
+++ b/pwa/src/shared/jukebox/engine/selection.test.ts
@@ -60,6 +60,7 @@ describe("PWA branch ramp parity", () => {
       stop() {},
       seek(_time: number) {},
       scheduleJump(_targetTime: number, _audioStart: number) {},
+      cancelScheduledJump() {},
       getCurrentTime() {
         return 0;
       },
@@ -135,6 +136,7 @@ describe("PWA branch ramp parity", () => {
       stop() {},
       seek(_time: number) {},
       scheduleJump(_targetTime: number, _audioStart: number) {},
+      cancelScheduledJump() {},
       getCurrentTime() {
         return 0;
       },

--- a/pwa/src/shared/jukebox/engine/selection.ts
+++ b/pwa/src/shared/jukebox/engine/selection.ts
@@ -2,7 +2,7 @@ import { JukeboxConfig, JukeboxGraphState, QuantumBase } from "./types";
 
 export interface BranchState {
   curRandomBranchChance: number;
-  lastDestBySource?: Map<number, number>;
+  lastDestBySource?: Map<number, number> | null;
 }
 
 const REFERENCE_BEAT_DURATION_SECONDS = 0.5;

--- a/web/src/app/playback.ts
+++ b/web/src/app/playback.ts
@@ -608,8 +608,8 @@ function startJukeboxPlayback(context: AppContext, resetSession: boolean) {
   } else {
     engine.syncToPlaybackPosition();
   }
-  engine.startJukebox(resetSession);
   engine.play();
+  engine.startJukebox(resetSession);
   state.lastPlayStamp = performance.now();
   state.isRunning = true;
   state.isPaused = false;
@@ -662,8 +662,8 @@ export function startJukeboxFromBeat(context: AppContext, index: number) {
   engine.seekToBeat(index);
   state.lastBeatIndex = index;
   if (!state.isRunning) {
-    engine.startJukebox(false);
     engine.play();
+    engine.startJukebox(false);
     state.lastPlayStamp = performance.now();
     state.isRunning = true;
     state.isPaused = false;

--- a/web/src/audio/BufferedAudioPlayer.test.ts
+++ b/web/src/audio/BufferedAudioPlayer.test.ts
@@ -251,11 +251,55 @@ describe("BufferedAudioPlayer", () => {
     await player.loadBuffer({ duration: 10 } as AudioBuffer);
     player.play();
     expect(context.createdSources).toHaveLength(1);
-    player.scheduleJump(2, 0);
+    player.scheduleJump(2, 1);
     const firstPending = context.createdSources[1];
     expect(firstPending).toBeDefined();
-    player.scheduleJump(3, 0);
+    player.scheduleJump(3, 1);
     expect(firstPending?.stop).toHaveBeenCalled();
     expect(firstPending?.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules jumps from the current source cursor", async () => {
+    const context = new MockAudioContext();
+    context.currentTime = 10;
+    const player = new BufferedAudioPlayer(context as unknown as AudioContext);
+    await player.loadBuffer({ duration: 20 } as AudioBuffer);
+    player.play();
+    context.currentTime = 10.25;
+
+    player.scheduleJump(2, 1);
+
+    expect(context.createdSources).toHaveLength(2);
+    expect(context.createdSources[1]?.start).toHaveBeenCalledWith(11, 2, 18);
+    expect(context.createdSources[0]?.stop).toHaveBeenCalledWith(11);
+  });
+
+  it("skips stale jumps that are already past the source boundary", async () => {
+    const context = new MockAudioContext();
+    context.currentTime = 1;
+    const player = new BufferedAudioPlayer(context as unknown as AudioContext);
+    await player.loadBuffer({ duration: 20 } as AudioBuffer);
+    player.play();
+    context.currentTime = 1.01;
+
+    player.scheduleJump(2, 0);
+
+    expect(context.createdSources).toHaveLength(1);
+    expect(context.createdSources[0]?.stop).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending scheduled jump", async () => {
+    const context = new MockAudioContext();
+    context.currentTime = 1;
+    const player = new BufferedAudioPlayer(context as unknown as AudioContext);
+    await player.loadBuffer({ duration: 20 } as AudioBuffer);
+    player.play();
+    player.scheduleJump(2, 1);
+    const pending = context.createdSources[1];
+
+    player.cancelScheduledJump();
+
+    expect(pending?.stop).toHaveBeenCalled();
+    expect(pending?.disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/audio/BufferedAudioPlayer.ts
+++ b/web/src/audio/BufferedAudioPlayer.ts
@@ -68,6 +68,7 @@ const AUDIO_MODE_SETTINGS: Record<JukeboxAudioMode, AudioModeSettings> = {
 
 const REVERB_SECONDS = 2.5;
 const PAN_STEP = 0.007;
+const MAX_LATE_JUMP_FRAMES = 8;
 
 export class BufferedAudioPlayer {
   private context: AudioContext;
@@ -258,11 +259,19 @@ export class BufferedAudioPlayer {
     return this.playbackRate;
   }
 
-  scheduleJump(targetTime: number, audioStart: number) {
+  scheduleJump(targetTime: number, sourceStartTime: number) {
     if (!this.buffer || !this.playing) {
       return;
     }
-    const startTime = audioStart === 0 ? this.context.currentTime : audioStart;
+    const currentSourceTime = this.getCurrentTime();
+    this.clearPendingSwap();
+    const lateBy = currentSourceTime - sourceStartTime;
+    const maxLateSeconds = MAX_LATE_JUMP_FRAMES / this.context.sampleRate;
+    if (lateBy > maxLateSeconds) {
+      return;
+    }
+    const sourceLead = Math.max(0, sourceStartTime - currentSourceTime);
+    const startTime = this.context.currentTime + sourceLead / this.playbackRate;
     const source = this.context.createBufferSource();
     source.buffer = this.buffer;
     source.playbackRate.value = this.playbackRate;
@@ -288,10 +297,13 @@ export class BufferedAudioPlayer {
         // no-op
       }
     }
-    this.clearPendingSwap();
     this.pendingSource = source;
     this.pendingStartAt = startTime - targetTime / this.playbackRate;
     this.pendingSwapAt = startTime;
+  }
+
+  cancelScheduledJump() {
+    this.clearPendingSwap();
   }
 
   private stopSource() {

--- a/web/src/cast/main.ts
+++ b/web/src/cast/main.ts
@@ -794,8 +794,8 @@ async function bootstrap() {
     void recordPlay(jobId).catch((err) => {
       console.warn(`Failed to record cast play: ${String(err)}`);
     });
-    engine.startJukebox();
     engine.play();
+    engine.startJukebox();
     isTrackPaused = false;
     listenAccumulatedMs = 0;
     playStartAtMs = performance.now();
@@ -1027,9 +1027,12 @@ async function bootstrap() {
         if (isTrackPaused) {
           engine.syncToPlaybackPosition();
         }
+        engine.play();
         engine.startJukebox(!isTrackPaused);
       }
-      engine.play();
+      if (!player.isPlaying()) {
+        engine.play();
+      }
       if (playStartAtMs === null) {
         playStartAtMs = performance.now();
       }

--- a/web/src/engine/JukeboxEngine.rebuild.test.ts
+++ b/web/src/engine/JukeboxEngine.rebuild.test.ts
@@ -28,6 +28,7 @@ function makePlayer(): JukeboxPlayer {
     stop: vi.fn(),
     seek: vi.fn(),
     scheduleJump: vi.fn(),
+    cancelScheduledJump: vi.fn(),
     getCurrentTime: () => 0,
     getAudioTime: () => 0,
     getPlaybackRate: () => 1,

--- a/web/src/engine/JukeboxEngine.test.ts
+++ b/web/src/engine/JukeboxEngine.test.ts
@@ -84,6 +84,7 @@ function makePlayer(): JukeboxPlayer {
     stop: vi.fn(),
     seek: vi.fn(),
     scheduleJump: vi.fn(),
+    cancelScheduledJump: vi.fn(),
     getCurrentTime: () => 0,
     getAudioTime: () => 0,
     getPlaybackRate: () => 1,
@@ -188,6 +189,7 @@ describe("JukeboxEngine branching", () => {
 
     expect(engineAny.currentBeatIndex).toBe(0);
     expect(player.scheduleJump).toHaveBeenCalledTimes(1);
+    expect(player.scheduleJump).toHaveBeenCalledWith(0, 1);
     expect(engineAny.lastJumpFromIndex).toBe(1);
   });
 
@@ -226,7 +228,70 @@ describe("JukeboxEngine branching", () => {
 
     expect(engineAny.currentBeatIndex).toBe(0);
     expect(player.scheduleJump).toHaveBeenCalledTimes(1);
+    expect(player.scheduleJump).toHaveBeenCalledWith(0, 2);
     expect(engineAny.lastJumpFromIndex).toBe(1);
+  });
+
+  it("skips a branch when the source boundary is too close to schedule", () => {
+    const player = {
+      ...makePlayer(),
+      getCurrentTime: () => 0.95,
+    };
+    const engine = new JukeboxEngine(player, { randomMode: "seeded", seed: 1 });
+    const beats = [0, 1, 2].map(makeBeat);
+    linkBeats(beats);
+    const edge: Edge = {
+      id: 0,
+      src: beats[1],
+      dest: beats[0],
+      distance: 10,
+      deleted: false,
+    };
+    beats[1].neighbors = [edge];
+    beats[1].allNeighbors = [edge];
+    const graph: JukeboxGraphState = {
+      computedThreshold: 0,
+      currentThreshold: 0,
+      lastBranchPoint: 1,
+      totalBeats: beats.length,
+      longestReach: 0,
+      allEdges: [edge],
+    };
+
+    const engineAny = engine as unknown as {
+      analysis: TrackAnalysis;
+      graph: JukeboxGraphState;
+      beats: QuantumBase[];
+      currentBeatIndex: number;
+      nextAudioTime: number;
+      curRandomBranchChance: number;
+      lastJumpFromIndex: number | null;
+      advanceBeat: (audioTime: number) => void;
+    };
+    engineAny.analysis = makeAnalysis(beats);
+    engineAny.graph = graph;
+    engineAny.beats = beats;
+    engineAny.currentBeatIndex = 0;
+    engineAny.nextAudioTime = 10.05;
+    engineAny.curRandomBranchChance = engine.getConfig().minRandomBranchChance;
+
+    engineAny.advanceBeat(engineAny.nextAudioTime);
+
+    expect(engineAny.currentBeatIndex).toBe(1);
+    expect(player.scheduleJump).not.toHaveBeenCalled();
+    expect(engineAny.lastJumpFromIndex).toBe(null);
+  });
+
+  it("resetStats clears per-source branch repeat history", () => {
+    const engine = new JukeboxEngine(makePlayer());
+    const engineAny = engine as unknown as {
+      branchState: { lastDestBySource: Map<number, number> | null };
+    };
+    engineAny.branchState.lastDestBySource = new Map([[4, 1]]);
+
+    engine.resetStats();
+
+    expect(engineAny.branchState.lastDestBySource).toBeNull();
   });
 });
 

--- a/web/src/engine/JukeboxEngine.ts
+++ b/web/src/engine/JukeboxEngine.ts
@@ -5,7 +5,11 @@ import {
   backgroundClearTimeout,
   backgroundSetTimeout,
 } from "../shared/backgroundTimer";
-import { getBestLastBranchNeighborIndex, selectNextBeatIndex } from "./selection";
+import {
+  BranchState,
+  getBestLastBranchNeighborIndex,
+  selectNextBeatIndex,
+} from "./selection";
 import {
   JukeboxConfig,
   JukeboxGraphState,
@@ -28,8 +32,18 @@ export const DEFAULT_JUKEBOX_CONFIG: JukeboxConfig = {
 };
 
 const TICK_INTERVAL_MS = 50;
+const MIN_JUMP_SCHEDULE_LEAD_SECONDS = 0.08;
 
 type UpdateListener = (state: JukeboxState) => void;
+
+type PendingAdvance = {
+  boundaryAudioTime: number;
+  chosenIndex: number;
+  shouldJump: boolean;
+  targetTime: number | null;
+  jumpFromIndex: number | null;
+  sourceBoundaryTime: number | null;
+};
 
 export interface JukeboxEngineOptions {
   randomMode?: RandomMode;
@@ -42,7 +56,8 @@ export interface JukeboxPlayer {
   pause: () => void;
   stop: () => void;
   seek: (time: number) => void;
-  scheduleJump: (targetTime: number, audioStart: number) => void;
+  scheduleJump: (targetTime: number, sourceStartTime: number) => void;
+  cancelScheduledJump: () => void;
   getCurrentTime: () => number;
   getAudioTime: () => number;
   getPlaybackRate: () => number;
@@ -66,10 +81,14 @@ export class JukeboxEngine {
   private lastJumpFromIndex: number | null = null;
   private forceBranch = false;
   private bringItHomeMode = false;
+  private pendingAdvance: PendingAdvance | null = null;
   private deletedEdgeKeys = new Set<string>();
   private rng: () => number;
   private listener: UpdateListener | null = null;
-  private branchState = { curRandomBranchChance: 0 };
+  private branchState: BranchState = {
+    curRandomBranchChance: 0,
+    lastDestBySource: null,
+  };
 
   constructor(player: JukeboxPlayer, options: JukeboxEngineOptions = {}) {
     this.player = player;
@@ -94,9 +113,11 @@ export class JukeboxEngine {
     this.nextAudioTime = audioNow + beat.duration / playbackRate;
     this.curRandomBranchChance = this.config.minRandomBranchChance;
     this.branchState.curRandomBranchChance = this.curRandomBranchChance;
+    this.branchState.lastDestBySource = null;
     this.lastJumped = false;
     this.lastJumpTime = null;
     this.lastJumpFromIndex = null;
+    this.clearPendingAdvance(true);
   }
 
   loadAnalysis(data: unknown) {
@@ -125,6 +146,7 @@ export class JukeboxEngine {
     if (!this.analysis) {
       return;
     }
+    this.clearPendingAdvance(true);
     this.clearEdgeDeletionFlags();
     this.config.minLongBranch = Math.floor(this.analysis.beats.length / 5);
     this.graph = buildJumpGraph(this.analysis, this.config);
@@ -219,6 +241,7 @@ export class JukeboxEngine {
     this.lastJumped = false;
     this.lastJumpTime = null;
     this.lastJumpFromIndex = null;
+    this.clearPendingAdvance(true);
   }
 
   stopJukebox() {
@@ -241,6 +264,7 @@ export class JukeboxEngine {
 
   clearDeletedEdges() {
     this.deletedEdgeKeys.clear();
+    this.clearPendingAdvance(true);
     this.clearEdgeDeletionFlags();
   }
 
@@ -248,6 +272,7 @@ export class JukeboxEngine {
     const srcIndex = edge.src.which;
     const destIndex = edge.dest.which;
     this.deletedEdgeKeys.add(this.edgeKey(srcIndex, destIndex));
+    this.clearPendingAdvance(true);
     this.applyDeletedEdges();
   }
 
@@ -339,9 +364,11 @@ export class JukeboxEngine {
     this.beatsPlayed = 0;
     this.curRandomBranchChance = this.config.minRandomBranchChance;
     this.branchState.curRandomBranchChance = this.curRandomBranchChance;
+    this.branchState.lastDestBySource = null;
     this.lastJumped = false;
     this.lastJumpTime = null;
     this.lastJumpFromIndex = null;
+    this.clearPendingAdvance(true);
   }
 
   private tick() {
@@ -355,13 +382,17 @@ export class JukeboxEngine {
     }
 
     const audioTime = this.player.getAudioTime();
-    if (this.nextAudioTime === 0) {
+    if (this.currentBeatIndex < 0 && this.nextAudioTime === 0) {
+      this.initializeBeatClock(audioTime);
+    } else if (this.nextAudioTime === 0) {
       this.nextAudioTime = audioTime;
     }
 
     let guard = this.beats.length;
+    this.preparePendingAdvance(this.nextAudioTime);
     while (guard > 0 && audioTime >= this.nextAudioTime) {
       this.advanceBeat(this.nextAudioTime);
+      this.preparePendingAdvance(this.nextAudioTime);
       guard -= 1;
     }
     if (!this.ticking) {
@@ -382,29 +413,83 @@ export class JukeboxEngine {
     if (!this.analysis || !this.graph) {
       return;
     }
+    if (
+      this.currentBeatIndex >= 0 &&
+      this.bringItHomeMode &&
+      this.currentBeatIndex === this.beats.length - 1
+    ) {
+      this.ticking = false;
+      this.timerId = null;
+      this.nextAudioTime = Number.POSITIVE_INFINITY;
+      this.lastJumped = false;
+      this.lastJumpTime = null;
+      this.lastJumpFromIndex = null;
+      this.clearPendingAdvance(false);
+      return;
+    }
+    const advance =
+      this.pendingAdvance?.boundaryAudioTime === audioTime
+        ? this.pendingAdvance
+        : this.createPendingAdvance(audioTime, true);
+    if (!advance) {
+      return;
+    }
+    this.pendingAdvance = null;
+    this.commitAdvance(advance);
+  }
+
+  private preparePendingAdvance(boundaryAudioTime: number) {
+    if (this.currentBeatIndex < 0 || boundaryAudioTime <= 0) {
+      return;
+    }
+    if (
+      this.bringItHomeMode &&
+      this.currentBeatIndex === this.beats.length - 1
+    ) {
+      return;
+    }
+    if (this.pendingAdvance?.boundaryAudioTime === boundaryAudioTime) {
+      return;
+    }
+    this.pendingAdvance = this.createPendingAdvance(boundaryAudioTime, true);
+  }
+
+  private createPendingAdvance(
+    boundaryAudioTime: number,
+    scheduleJump: boolean,
+  ): PendingAdvance | null {
+    if (!this.analysis || !this.graph) {
+      return null;
+    }
     const currentIndex = this.currentBeatIndex;
     const beatsCount = this.beats.length;
     let chosenIndex = 0;
     let shouldJump = false;
     let jumpFromIndex: number | null = null;
+    let sourceBoundaryTime: number | null = null;
 
     if (currentIndex >= 0) {
-      const isFinalBeat = currentIndex === beatsCount - 1;
-      if (this.bringItHomeMode && isFinalBeat) {
-        this.ticking = false;
-        this.timerId = null;
-        this.nextAudioTime = Number.POSITIVE_INFINITY;
-        this.lastJumped = false;
-        this.lastJumpTime = null;
-        this.lastJumpFromIndex = null;
-        return;
-      }
       const nextIndex = currentIndex + 1;
       const wrappedIndex = nextIndex >= beatsCount ? 0 : nextIndex;
       if (this.bringItHomeMode) {
         chosenIndex = wrappedIndex;
       } else {
         const seed = this.beats[wrappedIndex];
+        const wrappedToStart =
+          wrappedIndex === 0 && currentIndex === beatsCount - 1;
+        sourceBoundaryTime = wrappedToStart
+          ? this.beats[currentIndex].start + this.beats[currentIndex].duration
+          : seed.start;
+        if (!wrappedToStart && !this.hasJumpScheduleLead(sourceBoundaryTime)) {
+          return {
+            boundaryAudioTime,
+            chosenIndex: wrappedIndex,
+            shouldJump: false,
+            targetTime: null,
+            jumpFromIndex: null,
+            sourceBoundaryTime: null,
+          };
+        }
         this.branchState.curRandomBranchChance = this.curRandomBranchChance;
         const selection = selectNextBeatIndex(
           seed,
@@ -417,8 +502,6 @@ export class JukeboxEngine {
         this.curRandomBranchChance = this.branchState.curRandomBranchChance;
         shouldJump = selection.jumped;
         chosenIndex = shouldJump ? selection.index : wrappedIndex;
-        const wrappedToStart =
-          wrappedIndex === 0 && currentIndex === beatsCount - 1;
         if (wrappedToStart) {
           shouldJump = true;
         }
@@ -431,23 +514,72 @@ export class JukeboxEngine {
     }
 
     const targetBeat = this.beats[chosenIndex];
-    if (shouldJump) {
-      const targetTime = targetBeat.start;
-      this.player.scheduleJump(targetTime, audioTime);
+    if (!targetBeat) {
+      return null;
+    }
+    const targetTime = shouldJump ? targetBeat.start : null;
+    if (scheduleJump && targetTime !== null && sourceBoundaryTime !== null) {
+      this.player.scheduleJump(targetTime, sourceBoundaryTime);
+    }
+    return {
+      boundaryAudioTime,
+      chosenIndex,
+      shouldJump,
+      targetTime,
+      jumpFromIndex,
+      sourceBoundaryTime,
+    };
+  }
+
+  private commitAdvance(advance: PendingAdvance) {
+    const targetBeat = this.beats[advance.chosenIndex];
+    if (advance.shouldJump) {
       this.lastJumped = true;
-      this.lastJumpTime = targetTime;
-      this.lastJumpFromIndex = jumpFromIndex;
+      this.lastJumpTime = advance.targetTime;
+      this.lastJumpFromIndex = advance.jumpFromIndex;
     } else {
       this.lastJumped = false;
       this.lastJumpTime = null;
       this.lastJumpFromIndex = null;
     }
 
-    this.currentBeatIndex = chosenIndex;
-    const startTime = this.nextAudioTime === 0 ? audioTime : this.nextAudioTime;
+    this.currentBeatIndex = advance.chosenIndex;
     const playbackRate = this.getPlaybackRate();
-    this.nextAudioTime = startTime + targetBeat.duration / playbackRate;
+    this.nextAudioTime =
+      advance.boundaryAudioTime + targetBeat.duration / playbackRate;
     this.beatsPlayed += 1;
+  }
+
+  private initializeBeatClock(audioTime: number) {
+    const trackTime = this.player.getCurrentTime();
+    const beatIndex = this.findBeatIndexByTime(trackTime);
+    if (beatIndex < 0 || beatIndex >= this.beats.length) {
+      this.nextAudioTime = audioTime;
+      return;
+    }
+    const beat = this.beats[beatIndex];
+    const elapsedInBeat = Math.max(
+      0,
+      Math.min(beat.duration, trackTime - beat.start),
+    );
+    const remainingInBeat = Math.max(0, beat.duration - elapsedInBeat);
+    this.currentBeatIndex = beatIndex;
+    this.beatsPlayed = Math.max(this.beatsPlayed, beatIndex + 1);
+    this.nextAudioTime = audioTime + remainingInBeat / this.getPlaybackRate();
+  }
+
+  private clearPendingAdvance(cancelScheduledJump: boolean) {
+    if (cancelScheduledJump && this.pendingAdvance?.targetTime !== null) {
+      this.player.cancelScheduledJump();
+    }
+    this.pendingAdvance = null;
+  }
+
+  private hasJumpScheduleLead(sourceBoundaryTime: number): boolean {
+    return (
+      sourceBoundaryTime - this.player.getCurrentTime() >=
+      MIN_JUMP_SCHEDULE_LEAD_SECONDS
+    );
   }
 
   private getPlaybackRate(): number {

--- a/web/src/engine/deleteResetParityFixtures.test.ts
+++ b/web/src/engine/deleteResetParityFixtures.test.ts
@@ -65,6 +65,7 @@ function makePlayer(): JukeboxPlayer {
     stop: vi.fn(),
     seek: vi.fn(),
     scheduleJump: vi.fn(),
+    cancelScheduledJump: vi.fn(),
     getCurrentTime: () => 0,
     getAudioTime: () => 0,
     getPlaybackRate: () => 1,

--- a/web/src/engine/pathReproParityFixtures.test.ts
+++ b/web/src/engine/pathReproParityFixtures.test.ts
@@ -94,6 +94,7 @@ function makePlayer(): JukeboxPlayer {
     stop: vi.fn(),
     seek: vi.fn(),
     scheduleJump: vi.fn(),
+    cancelScheduledJump: vi.fn(),
     getCurrentTime: () => 0,
     getAudioTime: () => 0,
     getPlaybackRate: () => 1,

--- a/web/src/engine/rebuildParityFixtures.test.ts
+++ b/web/src/engine/rebuildParityFixtures.test.ts
@@ -57,6 +57,7 @@ function makePlayer(): JukeboxPlayer {
     stop: vi.fn(),
     seek: vi.fn(),
     scheduleJump: vi.fn(),
+    cancelScheduledJump: vi.fn(),
     getCurrentTime: () => 0,
     getAudioTime: () => 0,
     getPlaybackRate: () => 1,

--- a/web/src/engine/selection.ts
+++ b/web/src/engine/selection.ts
@@ -2,7 +2,7 @@ import { JukeboxConfig, JukeboxGraphState, QuantumBase } from "./types";
 
 export interface BranchState {
   curRandomBranchChance: number;
-  lastDestBySource?: Map<number, number>;
+  lastDestBySource?: Map<number, number> | null;
 }
 
 const REFERENCE_BEAT_DURATION_SECONDS = 0.5;


### PR DESCRIPTION
- Fixes branch jump timing drift, most noticeable on the first scheduled jump after playback starts.
- Schedules jumps against the decoded source beat boundary instead of the output clock, with stale/late jump guards so missed boundaries are skipped rather than applied late.
- Adds cancellation for pending scheduled jumps on seek, reset, sync, graph rebuild, and edge deletion.