### PR TITLE
Swing audio mode

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -21,13 +21,15 @@ Audio results are cached locally in IndexedDB when available; browsers may evict
 data under storage pressure.
 
 ## Extras audio modes
-- Available modes: `off`, `nightcore`, `daycore`, `vaporwave`, `eight_d`, `lofi`.
+- Available modes: `off`, `nightcore`, `daycore`, `vaporwave`, `eight_d`, `lofi`, `swing`.
 - UI labels/tooltips:
+  - Normal
   - Nightcore (Fast & Bright)
   - Daycore (Slow & Deep)
   - Vaporwave (Muffled & Slow)
   - 8D Audio (Spinning/Spatial)
   - Lofi (Radio Filter)
+  - Swing (pre-renders a pitch-preserved swung buffer with Rubber Band WASM)
 - Shared listen URLs can include `am=<mode>` (for example `am=nightcore`).
 
 ## Keyboard shortcuts

--- a/web/index.html
+++ b/web/index.html
@@ -796,7 +796,7 @@
                       value="off"
                       checked
                     />
-                    Off
+                    Normal
                   </label>
                   <label class="audio-mode-option" title="Fast & Bright">
                     <input
@@ -847,6 +847,19 @@
                       title="Radio Filter"
                     />
                     Lofi
+                  </label>
+                  <label
+                    class="audio-mode-option"
+                    title="Adds a swung feel by stretching and compressing each beat internally."
+                  >
+                    <input
+                      id="audio-mode-swing"
+                      type="radio"
+                      name="audio-mode"
+                      value="swing"
+                      title="Adds a swung feel by stretching and compressing each beat internally."
+                    />
+                    Swing
                   </label>
                 </div>
               </div>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "abortcontroller-polyfill": "^1.7.5",
         "core-js": "^3.38.1",
-        "regenerator-runtime": "^0.14.1"
+        "regenerator-runtime": "^0.14.1",
+        "rubberband-wasm": "^3.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -4677,6 +4678,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.54.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rubberband-wasm": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/rubberband-wasm/-/rubberband-wasm-3.3.0.tgz",
+      "integrity": "sha512-N0aABkKa1Cuxh/OiK9wHAuO7K/brSCOlHHNwlYfpAgTRtQPZFFxNr20NbsQyokVkw+1mZMcw+cT+3svHG6tPQQ==",
+      "license": "GPLv2"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "abortcontroller-polyfill": "^1.7.5",
     "core-js": "^3.38.1",
-    "regenerator-runtime": "^0.14.1"
+    "regenerator-runtime": "^0.14.1",
+    "rubberband-wasm": "^3.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
@@ -24,8 +25,8 @@
     "eslint": "^9.36.0",
     "globals": "^16.4.0",
     "terser": "^5.46.0",
-    "typescript-eslint": "^8.44.1",
     "typescript": "^5.4.5",
+    "typescript-eslint": "^8.44.1",
     "vite": "^5.4.0",
     "vitest": "^1.6.0"
   }

--- a/web/src/app/bootstrap.ts
+++ b/web/src/app/bootstrap.ts
@@ -144,6 +144,8 @@ export function bootstrap() {
     bringItHomeMode: false,
     branchStatsEnabled,
     jukeboxAudioMode: "off",
+    swingPreparing: false,
+    swingRenderToken: 0,
     selectedEdge: null,
     topSongsRefreshTimer: null,
     topSongsLoaded: false,

--- a/web/src/app/context.ts
+++ b/web/src/app/context.ts
@@ -41,6 +41,8 @@ export type AppState = {
   bringItHomeMode: boolean;
   branchStatsEnabled: boolean;
   jukeboxAudioMode: JukeboxAudioMode;
+  swingPreparing: boolean;
+  swingRenderToken: number;
   selectedEdge: Edge | null;
   topSongsRefreshTimer: number | null;
   topSongsLoaded: boolean;

--- a/web/src/app/elements.ts
+++ b/web/src/app/elements.ts
@@ -347,6 +347,10 @@ export function getElements() {
     document.querySelector<HTMLInputElement>("#audio-mode-lofi"),
     "#audio-mode-lofi"
   );
+  const audioModeSwingInput = requireElement(
+    document.querySelector<HTMLInputElement>("#audio-mode-swing"),
+    "#audio-mode-swing"
+  );
   const searchInput = requireElement(
     document.querySelector<HTMLInputElement>("#search-input"),
     "#search-input"
@@ -611,6 +615,7 @@ export function getElements() {
     audioModeVaporwaveInput,
     audioModeEightDInput,
     audioModeLofiInput,
+    audioModeSwingInput,
     searchInput,
     searchButton,
     searchSubtabs,

--- a/web/src/app/playback.test.ts
+++ b/web/src/app/playback.test.ts
@@ -16,6 +16,7 @@ import {
   syncTuningTabsUI,
   syncTuningUI,
   togglePlayback,
+  updateVizVisibility,
   updateListenTimeDisplay,
 } from "./playback";
 import { setWindowUrl } from "./__tests__/test-utils";
@@ -140,6 +141,7 @@ function createElements() {
     audioModeVaporwaveInput: createInput(),
     audioModeEightDInput: createInput(),
     audioModeLofiInput: createInput(),
+    audioModeSwingInput: createInput(),
     extrasEnabledInput: createInput(),
     bringHomeEnabledInput: createInput(),
     extrasJukeboxOnlyHint: { classList: createClassList() },
@@ -164,6 +166,11 @@ function createElements() {
     analysisStatus: createSpan(),
     analysisSpinner: { classList: createClassList() },
     analysisProgress: createSpan(),
+    toast: {
+      classList: createClassList(),
+      innerHTML: "",
+      textContent: "",
+    },
     beatsPlayedEl: createSpan(),
     playButton: createPlayButton(),
     bringHomeLabel: { classList: createClassList() },
@@ -232,6 +239,8 @@ function createContext(overrides?: Partial<AppContext>): AppContext {
     stop: vi.fn(),
     seek: vi.fn(),
     setJukeboxAudioMode: vi.fn(),
+    getSourceBuffer: vi.fn(() => null),
+    setRenderedJukeboxAudioBuffer: vi.fn(),
   };
   const autocanonizer = {
     setAnalysis: vi.fn(),
@@ -287,6 +296,8 @@ function createContext(overrides?: Partial<AppContext>): AppContext {
       lastBeatIndex: null,
       branchStatsEnabled: false,
       jukeboxAudioMode: "off",
+      swingPreparing: false,
+      swingRenderToken: 0,
       listenTimerId: null,
       pollController: null,
       wakeLock: null,
@@ -707,6 +718,10 @@ describe("playback controls", () => {
       setInterval;
     (globalThis.window as unknown as { clearInterval: typeof clearInterval }).clearInterval =
       clearInterval;
+    (globalThis.window as unknown as { setTimeout: typeof setTimeout }).setTimeout =
+      setTimeout;
+    (globalThis.window as unknown as { clearTimeout: typeof clearTimeout }).clearTimeout =
+      clearTimeout;
   });
 
   it("pauses and resumes without resetting when already started", () => {
@@ -740,6 +755,65 @@ describe("playback controls", () => {
     expect(context.engine.syncToPlaybackPosition).toHaveBeenCalledTimes(2);
     expect(context.state.isRunning).toBe(true);
     expect(context.state.isPaused).toBe(false);
+  });
+
+  it("blocks jukebox playback while swing mode is preparing", () => {
+    const context = createContext();
+    context.state.audioLoaded = true;
+    context.state.analysisLoaded = true;
+    context.state.jukeboxAudioMode = "swing";
+    context.state.swingPreparing = true;
+    (context.player.getDuration as ReturnType<typeof vi.fn>).mockReturnValue(120);
+
+    togglePlayback(context);
+
+    expect(context.engine.play).not.toHaveBeenCalled();
+    expect(context.engine.startJukebox).not.toHaveBeenCalled();
+    expect(context.state.isRunning).toBe(false);
+    expect(context.elements.playButton.disabled).toBe(true);
+    expect(context.elements.playButton.setAttribute).toHaveBeenLastCalledWith(
+      "aria-label",
+      "Preparing Swing mode",
+    );
+    expect(context.elements.vizPlayButton.disabled).toBe(true);
+  });
+
+  it("shows only loading status panel while swing mode is preparing", () => {
+    const context = createContext();
+    context.state.audioLoaded = true;
+    context.state.analysisLoaded = true;
+    context.state.jukeboxAudioMode = "swing";
+    context.state.swingPreparing = true;
+
+    updateVizVisibility(context);
+
+    expect(context.elements.playStatusPanel.classList.remove).toHaveBeenCalledWith(
+      "hidden",
+    );
+    expect(context.elements.playMenu.classList.add).toHaveBeenCalledWith("hidden");
+    expect(context.elements.vizPanel.classList.add).toHaveBeenCalledWith("hidden");
+    expect(context.elements.playButton.classList.add).toHaveBeenCalledWith("hidden");
+    expect(context.elements.vizSelect.disabled).toBe(true);
+  });
+
+  it("blocks beat-start playback while swing mode is preparing", () => {
+    const context = createContext();
+    context.state.playMode = "jukebox";
+    context.state.jukeboxAudioMode = "swing";
+    context.state.swingPreparing = true;
+    context.state.vizData = {
+      beats: [{ start: 2, duration: 1 }],
+      edges: [],
+    } as unknown as AppContext["state"]["vizData"];
+    (context.player.getDuration as ReturnType<typeof vi.fn>).mockReturnValue(120);
+
+    startJukeboxFromBeat(context, 0);
+
+    expect(context.player.seek).not.toHaveBeenCalled();
+    expect(context.engine.seekToBeat).not.toHaveBeenCalled();
+    expect(context.engine.play).not.toHaveBeenCalled();
+    expect(context.engine.startJukebox).not.toHaveBeenCalled();
+    expect(context.elements.playButton.disabled).toBe(true);
   });
 
   it("stop clears paused state and forces next play to restart", () => {

--- a/web/src/app/playback.ts
+++ b/web/src/app/playback.ts
@@ -1,5 +1,7 @@
 import type { AppContext, TabId } from "./context";
 import type { JukeboxAudioMode } from "../audio/BufferedAudioPlayer";
+import { getOrCreateSwingBuffer } from "../audio/swingBufferCache";
+import { renderSwingBuffer } from "../audio/swingRenderer";
 import {
   ANALYSIS_POLL_INTERVAL_MS,
   LISTEN_TIMER_INTERVAL_MS,
@@ -24,6 +26,7 @@ import {
 import { storeAnchorHighlight } from "./anchorHighlight";
 import { storeBranchStatsEnabled } from "./extrasMode";
 import { setAutoMarqueeText } from "./marquee";
+import { showToast } from "./ui";
 import {
   isAnalysisComplete,
   isAnalysisFailed,
@@ -36,6 +39,10 @@ const RANDOM_BRANCH_DELTA_PERCENT_SCALE = 100 / MAX_RANDOM_BRANCH_DELTA;
 const GENERIC_LOAD_ERROR_MESSAGE =
   "ERROR: Something went wrong. Please try again or report an issue on GitHub.";
 
+function formatAudioModeLabel(audioMode: JukeboxAudioMode) {
+  return audioMode === "swing" ? "swing" : audioMode;
+}
+
 function formatTrackTitle(
   baseTitle: string,
   playMode: AppContext["state"]["playMode"],
@@ -45,7 +52,7 @@ function formatTrackTitle(
     return `${baseTitle} (autocanonized)`;
   }
   if (audioMode !== "off") {
-    return `${baseTitle} (${audioMode})`;
+    return `${baseTitle} (${formatAudioModeLabel(audioMode)})`;
   }
   return baseTitle;
 }
@@ -184,6 +191,15 @@ export function updateTrackInfo(context: AppContext) {
 
 export function updateVizVisibility(context: AppContext) {
   const { autocanonizer, elements, jukebox, state } = context;
+  if (state.swingPreparing) {
+    elements.playStatusPanel.classList.remove("hidden");
+    elements.playMenu.classList.add("hidden");
+    elements.vizPanel.classList.add("hidden");
+    elements.playButton.classList.add("hidden");
+    elements.vizSelect.disabled = true;
+    updatePlayButton(context);
+    return;
+  }
   if (state.audioLoaded && state.analysisLoaded) {
     elements.playStatusPanel.classList.add("hidden");
     elements.playMenu.classList.remove("hidden");
@@ -251,7 +267,122 @@ function getSelectedAudioMode(context: AppContext): JukeboxAudioMode {
   if (elements.audioModeLofiInput.checked) {
     return "lofi";
   }
+  if (elements.audioModeSwingInput.checked) {
+    return "swing";
+  }
   return "off";
+}
+
+function getCurrentSwingSourceIdentity(context: AppContext): string | null {
+  const { state } = context;
+  return state.lastJobId ?? state.lastYouTubeId ?? null;
+}
+
+function canPrepareSwingMode(context: AppContext) {
+  return (
+    context.state.playMode === "jukebox" &&
+    context.state.audioLoaded &&
+    context.state.analysisLoaded &&
+    context.player.getSourceBuffer() !== null &&
+    context.state.vizData !== null &&
+    context.state.vizData.beats.length > 0
+  );
+}
+
+function isPlaybackBlockedForSwing(context: AppContext) {
+  const { state } = context;
+  return (
+    state.playMode === "jukebox" &&
+    state.jukeboxAudioMode === "swing" &&
+    state.swingPreparing
+  );
+}
+
+function prepareSwingMode(context: AppContext) {
+  if (context.state.jukeboxAudioMode !== "swing") {
+    return;
+  }
+  const sourceBuffer = context.player.getSourceBuffer();
+  const beats = context.state.vizData?.beats;
+  if (!sourceBuffer || !beats || beats.length === 0) {
+    return;
+  }
+  if (context.state.isRunning) {
+    pausePlayback(context);
+  }
+  const renderToken = context.state.swingRenderToken + 1;
+  context.state.swingRenderToken = renderToken;
+  context.state.swingPreparing = true;
+  context.elements.analysisStatus.textContent = "Adding swing to the track...";
+  context.elements.analysisSpinner.classList.remove("hidden");
+  context.elements.analysisProgress.textContent = "0%";
+  updateVizVisibility(context);
+  updatePlayButton(context);
+
+  const sourceIdentity = getCurrentSwingSourceIdentity(context);
+  void getOrCreateSwingBuffer(sourceBuffer, sourceIdentity, () =>
+    renderSwingBuffer(sourceBuffer, beats, {
+      onProgress: (progress) => {
+        if (
+          context.state.swingRenderToken !== renderToken ||
+          context.state.jukeboxAudioMode !== "swing"
+        ) {
+          return;
+        }
+        const percent = Math.max(0, Math.min(100, Math.round(progress * 100)));
+        context.elements.analysisProgress.textContent = `${percent}%`;
+      },
+    }),
+  )
+    .then((buffer) => {
+      if (
+        context.state.swingRenderToken !== renderToken ||
+        context.state.jukeboxAudioMode !== "swing"
+      ) {
+        return;
+      }
+      context.state.swingPreparing = false;
+      context.player.setRenderedJukeboxAudioBuffer("swing", buffer);
+      context.player.setJukeboxAudioMode("swing");
+      context.elements.analysisStatus.textContent = "Swing mode ready.";
+      context.elements.analysisSpinner.classList.add("hidden");
+      context.elements.analysisProgress.textContent = "";
+      updateVizVisibility(context);
+      if (context.state.isRunning || context.state.isPaused) {
+        context.engine.syncToPlaybackPosition();
+      }
+      updatePlayButton(context);
+    })
+    .catch((err: unknown) => {
+      if (context.state.swingRenderToken !== renderToken) {
+        return;
+      }
+      console.warn(`Swing render failed: ${String(err)}`);
+      context.state.swingPreparing = false;
+      context.state.jukeboxAudioMode = "off";
+      context.player.setJukeboxAudioMode("off");
+      context.elements.analysisStatus.textContent = "Swing mode failed.";
+      context.elements.analysisSpinner.classList.add("hidden");
+      context.elements.analysisProgress.textContent = "";
+      updateVizVisibility(context);
+      syncTuningParamsState(context);
+      writeTuningParamsToUrl(context.state.tuningParams, true);
+      updatePlayButton(context);
+      showToast(context, "Swing mode failed. Using Normal mode.", {
+        icon: "error",
+        tone: "error",
+      });
+    });
+}
+
+function maybePrepareSwingMode(context: AppContext) {
+  if (context.state.jukeboxAudioMode !== "swing") {
+    return;
+  }
+  if (!canPrepareSwingMode(context)) {
+    return;
+  }
+  prepareSwingMode(context);
 }
 
 function syncBringItHomeLabels(context: AppContext) {
@@ -277,12 +408,14 @@ export function syncExtrasUI(context: AppContext) {
   elements.audioModeVaporwaveInput.checked = audioMode === "vaporwave";
   elements.audioModeEightDInput.checked = audioMode === "eight_d";
   elements.audioModeLofiInput.checked = audioMode === "lofi";
+  elements.audioModeSwingInput.checked = audioMode === "swing";
   elements.audioModeOffInput.disabled = !inJukeboxMode;
   elements.audioModeNightcoreInput.disabled = !inJukeboxMode;
   elements.audioModeDaycoreInput.disabled = !inJukeboxMode;
   elements.audioModeVaporwaveInput.disabled = !inJukeboxMode;
   elements.audioModeEightDInput.disabled = !inJukeboxMode;
   elements.audioModeLofiInput.disabled = !inJukeboxMode;
+  elements.audioModeSwingInput.disabled = !inJukeboxMode;
 }
 
 export type TuningModalTab = "tuning" | "extras";
@@ -348,13 +481,26 @@ export function applyExtrasChanges(context: AppContext): ExtrasApplyResult {
   storeBranchStatsEnabled(state.branchStatsEnabled);
   const nextAudioMode = getSelectedAudioMode(context);
   state.jukeboxAudioMode = nextAudioMode;
-  player.setJukeboxAudioMode(nextAudioMode);
-  if (
-    previousAudioMode !== nextAudioMode &&
-    state.playMode === "jukebox" &&
-    (state.isRunning || state.isPaused)
-  ) {
-    engine.syncToPlaybackPosition();
+  if (nextAudioMode === "swing") {
+    if (canPrepareSwingMode(context)) {
+      prepareSwingMode(context);
+    } else {
+      showToast(context, "Swing mode will prepare once audio is loaded", {
+        icon: "hourglass_top",
+      });
+    }
+  } else {
+    state.swingRenderToken += 1;
+    state.swingPreparing = false;
+    player.setJukeboxAudioMode(nextAudioMode);
+    if (
+      previousAudioMode !== nextAudioMode &&
+      state.playMode === "jukebox" &&
+      (state.isRunning || state.isPaused)
+    ) {
+      engine.syncToPlaybackPosition();
+    }
+    updatePlayButton(context);
   }
   syncTuningParamsState(context);
   writeTuningParamsToUrl(state.tuningParams, true);
@@ -375,8 +521,11 @@ export function resetExtrasDefaults(context: AppContext): ExtrasApplyResult {
   state.branchStatsEnabled = false;
   elements.branchStatsPopup.classList.add("hidden");
   storeBranchStatsEnabled(false);
+  state.swingRenderToken += 1;
+  state.swingPreparing = false;
   state.jukeboxAudioMode = "off";
   player.setJukeboxAudioMode("off");
+  updatePlayButton(context);
   if (
     previousAudioMode !== "off" &&
     state.playMode === "jukebox" &&
@@ -584,6 +733,11 @@ function pausePlayback(context: AppContext) {
 
 function startJukeboxPlayback(context: AppContext, resetSession: boolean) {
   const { engine, elements, jukebox, player, state } = context;
+  if (isPlaybackBlockedForSwing(context)) {
+    showToast(context, "Preparing Swing mode...", { icon: "hourglass_top" });
+    updatePlayButton(context);
+    return;
+  }
   if (player.getDuration() === null) {
     console.warn("Audio not loaded");
     if (!resetSession) {
@@ -647,6 +801,11 @@ export function togglePlayback(context: AppContext) {
 export function startJukeboxFromBeat(context: AppContext, index: number) {
   const { engine, player, state } = context;
   if (state.playMode !== "jukebox") {
+    return;
+  }
+  if (isPlaybackBlockedForSwing(context)) {
+    showToast(context, "Preparing Swing mode...", { icon: "hourglass_top" });
+    updatePlayButton(context);
     return;
   }
   if (player.getDuration() === null) {
@@ -720,12 +879,24 @@ export function startAutocanonizerPlayback(
 function updatePlayButton(context: AppContext) {
   const { state } = context;
   const isRunning = state.isRunning;
-  const label = isRunning ? "Pause" : state.isPaused ? "Resume" : "Play";
+  const isBlocked = isPlaybackBlockedForSwing(context);
+  const label = isBlocked
+    ? "Preparing Swing mode"
+    : isRunning
+      ? "Pause"
+      : state.isPaused
+        ? "Resume"
+        : "Play";
   const updateButton = (button: HTMLButtonElement) => {
     const icon = button.querySelector<HTMLSpanElement>(".play-icon");
     if (icon) {
-      icon.textContent = isRunning ? "pause" : "play_arrow";
+      icon.textContent = isBlocked
+        ? "hourglass_top"
+        : isRunning
+          ? "pause"
+          : "play_arrow";
     }
+    button.disabled = isBlocked;
     button.title = label;
     button.setAttribute("aria-label", label);
   };
@@ -754,6 +925,8 @@ export function resetForNewTrack(
     state.jukeboxAudioMode = "off";
     player.setJukeboxAudioMode("off");
   }
+  state.swingRenderToken += 1;
+  state.swingPreparing = false;
   cancelPoll(context);
   state.shiftBranching = false;
   engine.setForceBranch(false);
@@ -834,6 +1007,7 @@ export async function loadAudioFromJob(context: AppContext, jobId: string) {
     state.audioLoadInFlight = false;
     updateVizVisibility(context);
     updateTrackInfo(context);
+    maybePrepareSwingMode(context);
     const cacheId = state.lastYouTubeId ?? state.lastJobId;
     if (cacheId) {
       updateCachedTrack(cacheId, { audio: buffer, jobId }).catch((err) => {
@@ -876,6 +1050,7 @@ export function applyAnalysisResult(
   syncDeletedEdgeState(context);
   state.analysisLoaded = true;
   updateVizVisibility(context);
+  maybePrepareSwingMode(context);
   const resultTrack = response.result.track ?? null;
   const track = resultTrack ?? response.track;
   const title = track?.title;
@@ -1175,6 +1350,7 @@ export async function tryLoadCachedAudio(
     state.audioLoadInFlight = false;
     updateVizVisibility(context);
     updateTrackInfo(context);
+    maybePrepareSwingMode(context);
     return true;
   } catch (err) {
     console.warn(`Cache lookup failed: ${String(err)}`);

--- a/web/src/app/tuning.test.ts
+++ b/web/src/app/tuning.test.ts
@@ -95,11 +95,11 @@ describe("tuning params", () => {
 
   it("applies newly supported audio modes from params", () => {
     const context = createContext();
-    const params = new URLSearchParams("am=eight_d");
+    const params = new URLSearchParams("am=swing");
     const applied = applyTuningParamsToEngine(context, params);
     expect(applied).toBe(true);
-    expect(context.state.jukeboxAudioMode).toBe("eight_d");
-    expect(context.player.setJukeboxAudioMode).toHaveBeenCalledWith("eight_d");
+    expect(context.state.jukeboxAudioMode).toBe("swing");
+    expect(context.player.setJukeboxAudioMode).not.toHaveBeenCalled();
   });
 
   it("serializes only non-default tuning params", () => {

--- a/web/src/app/tuning.ts
+++ b/web/src/app/tuning.ts
@@ -11,7 +11,8 @@ function parseAudioMode(raw: string | null) {
     raw === "daycore" ||
     raw === "vaporwave" ||
     raw === "eight_d" ||
-    raw === "lofi"
+    raw === "lofi" ||
+    raw === "swing"
   ) {
     return raw;
   }
@@ -132,7 +133,9 @@ export function applyTuningParamsToEngine(
   const audioMode = parseAudioMode(params.get("am"));
   if (audioMode) {
     context.state.jukeboxAudioMode = audioMode;
-    context.player.setJukeboxAudioMode(audioMode);
+    if (audioMode !== "swing") {
+      context.player.setJukeboxAudioMode(audioMode);
+    }
   }
   return true;
 }

--- a/web/src/app/wire/playback.ts
+++ b/web/src/app/wire/playback.ts
@@ -83,6 +83,10 @@ function toSimilarityPercent(distance: number, maxDistance: number) {
   return Math.round(Math.max(0, Math.min(1, normalized)) * 100);
 }
 
+function formatAudioModeLabel(audioMode: AppState["jukeboxAudioMode"]) {
+  return audioMode === "swing" ? "swing" : audioMode;
+}
+
 function formatTrackTitle(
   baseTitle: string,
   playMode: AppState["playMode"],
@@ -92,7 +96,7 @@ function formatTrackTitle(
     return `${baseTitle} (autocanonized)`;
   }
   if (audioMode !== "off") {
-    return `${baseTitle} (${audioMode})`;
+    return `${baseTitle} (${formatAudioModeLabel(audioMode)})`;
   }
   return baseTitle;
 }

--- a/web/src/audio/BufferedAudioPlayer.test.ts
+++ b/web/src/audio/BufferedAudioPlayer.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BufferedAudioPlayer } from "./BufferedAudioPlayer";
 
 class MockGainNode {
-  gain = { value: 1 };
+  gain = {
+    value: 1,
+    setValueAtTime: vi.fn(),
+    linearRampToValueAtTime: vi.fn(),
+  };
   connect = vi.fn();
   disconnect = vi.fn();
 }
@@ -197,6 +201,34 @@ describe("BufferedAudioPlayer", () => {
     expect(bandPass).toBeDefined();
     expect(bandPass?.frequency.value).toBe(2000);
     expect(context.createdSources[0]?.playbackRate.value).toBe(1);
+  });
+
+  it("switches swing mode to a rendered buffer without playbackRate slicing", async () => {
+    const context = new MockAudioContext();
+    const player = new BufferedAudioPlayer(context as unknown as AudioContext);
+    const sourceBuffer = { duration: 2 } as AudioBuffer;
+    const swingBuffer = { duration: 2 } as AudioBuffer;
+    await player.loadBuffer(sourceBuffer);
+    player.setRenderedJukeboxAudioBuffer("swing", swingBuffer);
+    player.setJukeboxAudioMode("swing");
+    player.play();
+
+    expect(player.getPlaybackRate()).toBe(1);
+    expect(context.createdSources).toHaveLength(1);
+    expect(context.createdSources[0]?.buffer).toBe(swingBuffer);
+    expect(context.createdSources[0]?.start).toHaveBeenCalledWith(0, 0, 2);
+
+    player.stop();
+  });
+
+  it("keeps normal mode on the continuous source path", async () => {
+    const context = new MockAudioContext();
+    const player = new BufferedAudioPlayer(context as unknown as AudioContext);
+    await player.loadBuffer({ duration: 2 } as AudioBuffer);
+    player.play();
+
+    expect(context.createdSources).toHaveLength(1);
+    expect(context.createdSources[0]?.start).toHaveBeenCalledWith(0, 0, 2);
   });
 
   it("starts panning loop for eight_d mode and resets on mode change", async () => {

--- a/web/src/audio/BufferedAudioPlayer.ts
+++ b/web/src/audio/BufferedAudioPlayer.ts
@@ -4,7 +4,8 @@ export type JukeboxAudioMode =
   | "daycore"
   | "vaporwave"
   | "eight_d"
-  | "lofi";
+  | "lofi"
+  | "swing";
 
 type AudioModeSettings = {
   rate: number;
@@ -64,6 +65,14 @@ const AUDIO_MODE_SETTINGS: Record<JukeboxAudioMode, AudioModeSettings> = {
     reverbMix: 0.1,
     pan: false,
   },
+  swing: {
+    rate: 1,
+    highPassFrequency: null,
+    lowPassFrequency: null,
+    useBandPass: false,
+    reverbMix: 0,
+    pan: false,
+  },
 };
 
 const REVERB_SECONDS = 2.5;
@@ -72,6 +81,7 @@ const MAX_LATE_JUMP_FRAMES = 8;
 
 export class BufferedAudioPlayer {
   private context: AudioContext;
+  private originalBuffer: AudioBuffer | null = null;
   private buffer: AudioBuffer | null = null;
   private source: AudioBufferSourceNode | null = null;
   private pendingSource: AudioBufferSourceNode | null = null;
@@ -93,6 +103,8 @@ export class BufferedAudioPlayer {
   private playbackRate = AUDIO_MODE_SETTINGS.off.rate;
   private panAngle = 0;
   private panFrameId: number | null = null;
+  private renderedModeBuffers: Partial<Record<JukeboxAudioMode, AudioBuffer>> =
+    {};
 
   constructor(context?: AudioContext) {
     this.context = context ?? new AudioContext();
@@ -113,7 +125,9 @@ export class BufferedAudioPlayer {
 
   async loadBuffer(buffer: AudioBuffer) {
     this.stop();
+    this.originalBuffer = buffer;
     this.buffer = buffer;
+    this.renderedModeBuffers = {};
     this.offset = 0;
   }
 
@@ -124,6 +138,10 @@ export class BufferedAudioPlayer {
 
   getBuffer(): AudioBuffer | null {
     return this.buffer;
+  }
+
+  getSourceBuffer(): AudioBuffer | null {
+    return this.originalBuffer;
   }
 
   getContext(): AudioContext {
@@ -237,6 +255,7 @@ export class BufferedAudioPlayer {
     const resumeOffset = shouldResume ? this.getCurrentTime() : this.offset;
     this.audioMode = mode;
     this.playbackRate = AUDIO_MODE_SETTINGS[mode].rate;
+    this.buffer = this.getActiveBuffer();
     this.rebuildSourceChain();
     this.syncPanMotion();
     if (!this.buffer) {
@@ -249,6 +268,33 @@ export class BufferedAudioPlayer {
     const now = this.context.currentTime;
     this.stopSource();
     this.startSourceAt(this.offset, now);
+  }
+
+  setRenderedJukeboxAudioBuffer(
+    mode: Extract<JukeboxAudioMode, "swing">,
+    buffer: AudioBuffer,
+  ) {
+    this.renderedModeBuffers[mode] = buffer;
+    if (this.audioMode !== mode) {
+      return;
+    }
+    const shouldResume = this.playing;
+    const resumeOffset = shouldResume ? this.getCurrentTime() : this.offset;
+    this.buffer = this.getActiveBuffer();
+    if (!this.buffer) {
+      return;
+    }
+    this.offset = Math.max(0, Math.min(this.buffer.duration, resumeOffset));
+    if (!shouldResume) {
+      return;
+    }
+    const now = this.context.currentTime;
+    this.stopSource();
+    this.startSourceAt(this.offset, now);
+  }
+
+  private getActiveBuffer(): AudioBuffer | null {
+    return this.renderedModeBuffers[this.audioMode] ?? this.originalBuffer;
   }
 
   getJukeboxAudioMode(): JukeboxAudioMode {

--- a/web/src/audio/rubberBandAdapter.ts
+++ b/web/src/audio/rubberBandAdapter.ts
@@ -1,0 +1,97 @@
+import type { TimeStretchAdapter } from "./timeStretch";
+
+type WorkerRequest = {
+  type: "stretch";
+  id: number;
+  channels: Float32Array[];
+  sampleRate: number;
+  targetFrameCount: number;
+};
+
+type WorkerResponse =
+  | {
+      type: "result";
+      id: number;
+      channels: Float32Array[];
+    }
+  | {
+      type: "error";
+      id: number;
+      message: string;
+    };
+
+type PendingRequest = {
+  resolve: (channels: Float32Array[]) => void;
+  reject: (err: Error) => void;
+};
+
+export class RubberBandWorkerAdapter implements TimeStretchAdapter {
+  private worker: Worker | null = null;
+  private nextRequestId = 1;
+  private pending = new Map<number, PendingRequest>();
+
+  stretchSegment(
+    channels: Float32Array[],
+    sampleRate: number,
+    targetFrameCount: number,
+  ): Promise<Float32Array[]> {
+    const id = this.nextRequestId;
+    this.nextRequestId += 1;
+    const requestChannels = channels.map((channel) => new Float32Array(channel));
+    const request: WorkerRequest = {
+      type: "stretch",
+      id,
+      channels: requestChannels,
+      sampleRate,
+      targetFrameCount,
+    };
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.getWorker().postMessage(
+        request,
+        requestChannels.map((channel) => channel.buffer),
+      );
+    });
+  }
+
+  dispose() {
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+    for (const pending of this.pending.values()) {
+      pending.reject(new Error("Rubber Band worker disposed"));
+    }
+    this.pending.clear();
+  }
+
+  private getWorker() {
+    if (this.worker) {
+      return this.worker;
+    }
+    this.worker = new Worker(new URL("./rubberBandWorker.ts", import.meta.url), {
+      type: "module",
+    });
+    this.worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+      const response = event.data;
+      const pending = this.pending.get(response.id);
+      if (!pending) {
+        return;
+      }
+      this.pending.delete(response.id);
+      if (response.type === "error") {
+        pending.reject(new Error(response.message));
+        return;
+      }
+      pending.resolve(response.channels);
+    };
+    this.worker.onerror = () => {
+      const err = new Error("Rubber Band worker failed");
+      for (const pending of this.pending.values()) {
+        pending.reject(err);
+      }
+      this.pending.clear();
+    };
+    return this.worker;
+  }
+}

--- a/web/src/audio/rubberBandWorker.ts
+++ b/web/src/audio/rubberBandWorker.ts
@@ -1,0 +1,212 @@
+import {
+  RubberBandInterface,
+  RubberBandOption,
+} from "rubberband-wasm";
+import rubberBandWasmUrl from "rubberband-wasm/dist/rubberband.wasm?url";
+
+type StretchRequest = {
+  type: "stretch";
+  id: number;
+  channels: Float32Array[];
+  sampleRate: number;
+  targetFrameCount: number;
+};
+
+type StretchResponse =
+  | {
+      type: "result";
+      id: number;
+      channels: Float32Array[];
+    }
+  | {
+      type: "error";
+      id: number;
+      message: string;
+    };
+
+type WorkerScope = {
+  onmessage: ((event: MessageEvent<StretchRequest>) => void) | null;
+  postMessage(message: StretchResponse, transfer?: Transferable[]): void;
+};
+
+const workerSelf = self as unknown as WorkerScope;
+let rubberBandPromise: Promise<RubberBandInterface> | null = null;
+
+async function getRubberBand() {
+  rubberBandPromise ??= loadRubberBand();
+  return rubberBandPromise;
+}
+
+async function loadRubberBand() {
+  const response = await fetch(rubberBandWasmUrl);
+  const module = await WebAssembly.compile(await response.arrayBuffer());
+  return RubberBandInterface.initialize(module);
+}
+
+function fitChannelsToFrameCount(
+  channels: Float32Array[],
+  targetFrameCount: number,
+): Float32Array[] {
+  return channels.map((channel) => {
+    if (channel.length === targetFrameCount) {
+      return channel;
+    }
+    const fitted = new Float32Array(targetFrameCount);
+    fitted.set(channel.subarray(0, targetFrameCount));
+    if (channel.length > 0 && channel.length < targetFrameCount) {
+      fitted.fill(channel[channel.length - 1] ?? 0, channel.length);
+    }
+    return fitted;
+  });
+}
+
+async function stretchSegment(request: StretchRequest): Promise<Float32Array[]> {
+  const inputFrames = request.channels[0]?.length ?? 0;
+  if (
+    inputFrames === 0 ||
+    request.targetFrameCount <= 0 ||
+    request.channels.length === 0
+  ) {
+    return request.channels.map(() => new Float32Array(0));
+  }
+  if (inputFrames === request.targetFrameCount) {
+    return request.channels.map((channel) => new Float32Array(channel));
+  }
+
+  const rbApi = await getRubberBand();
+  const options =
+    RubberBandOption.RubberBandOptionProcessOffline |
+    RubberBandOption.RubberBandOptionStretchPrecise |
+    RubberBandOption.RubberBandOptionTransientsCrisp |
+    RubberBandOption.RubberBandOptionDetectorCompound |
+    RubberBandOption.RubberBandOptionPhaseLaminar |
+    RubberBandOption.RubberBandOptionPitchHighQuality |
+    RubberBandOption.RubberBandOptionChannelsTogether;
+  const timeRatio = request.targetFrameCount / inputFrames;
+  const rbState = rbApi.rubberband_new(
+    request.sampleRate,
+    request.channels.length,
+    options,
+    timeRatio,
+    1,
+  );
+  let channelArrayPtr = 0;
+  let channelDataPtrs: number[] = [];
+
+  try {
+    rbApi.rubberband_set_expected_input_duration(rbState, inputFrames);
+    rbApi.rubberband_set_time_ratio(rbState, timeRatio);
+    rbApi.rubberband_set_pitch_scale(rbState, 1);
+
+    const chunkFrames = Math.max(1, rbApi.rubberband_get_samples_required(rbState));
+    channelArrayPtr = rbApi.malloc(request.channels.length * 4);
+    channelDataPtrs = request.channels.map((channel, index) => {
+      const ptr = rbApi.malloc(Math.max(chunkFrames, channel.length) * 4);
+      rbApi.memWritePtr(channelArrayPtr + index * 4, ptr);
+      return ptr;
+    });
+
+    const chunks = request.channels.map(() => [] as Float32Array[]);
+    const retrieve = (final: boolean) => {
+      for (;;) {
+        const available = rbApi.rubberband_available(rbState);
+        if (available < 1) {
+          break;
+        }
+        if (!final && available < chunkFrames) {
+          break;
+        }
+        const wanted = Math.min(chunkFrames, available);
+        const received = rbApi.rubberband_retrieve(
+          rbState,
+          channelArrayPtr,
+          wanted,
+        );
+        channelDataPtrs.forEach((ptr, channelIndex) => {
+          chunks[channelIndex]?.push(new Float32Array(rbApi.memReadF32(ptr, received)));
+        });
+      }
+    };
+
+    for (let read = 0; read < inputFrames;) {
+      const remaining = Math.min(chunkFrames, inputFrames - read);
+      request.channels.forEach((channel, channelIndex) => {
+        rbApi.memWrite(
+          channelDataPtrs[channelIndex] as number,
+          channel.subarray(read, read + remaining),
+        );
+      });
+      read += remaining;
+      rbApi.rubberband_study(
+        rbState,
+        channelArrayPtr,
+        remaining,
+        read < inputFrames ? 0 : 1,
+      );
+    }
+
+    for (let read = 0; read < inputFrames;) {
+      const remaining = Math.min(chunkFrames, inputFrames - read);
+      request.channels.forEach((channel, channelIndex) => {
+        rbApi.memWrite(
+          channelDataPtrs[channelIndex] as number,
+          channel.subarray(read, read + remaining),
+        );
+      });
+      read += remaining;
+      rbApi.rubberband_process(
+        rbState,
+        channelArrayPtr,
+        remaining,
+        read < inputFrames ? 0 : 1,
+      );
+      retrieve(false);
+    }
+    retrieve(true);
+
+    const stretched = chunks.map((channelChunks) => {
+      const length = channelChunks.reduce((sum, chunk) => sum + chunk.length, 0);
+      const merged = new Float32Array(length);
+      let offset = 0;
+      for (const chunk of channelChunks) {
+        merged.set(chunk, offset);
+        offset += chunk.length;
+      }
+      return merged;
+    });
+    return fitChannelsToFrameCount(stretched, request.targetFrameCount);
+  } finally {
+    channelDataPtrs.forEach((ptr) => rbApi.free(ptr));
+    if (channelArrayPtr !== 0) {
+      rbApi.free(channelArrayPtr);
+    }
+    rbApi.rubberband_delete(rbState);
+  }
+}
+
+workerSelf.onmessage = (event: MessageEvent<StretchRequest>) => {
+  const request = event.data;
+  if (request.type !== "stretch") {
+    return;
+  }
+  stretchSegment(request)
+    .then((channels) => {
+      const response: StretchResponse = {
+        type: "result",
+        id: request.id,
+        channels,
+      };
+      workerSelf.postMessage(
+        response,
+        channels.map((channel) => channel.buffer) as Transferable[],
+      );
+    })
+    .catch((err: unknown) => {
+      const response: StretchResponse = {
+        type: "error",
+        id: request.id,
+        message: err instanceof Error ? err.message : String(err),
+      };
+      workerSelf.postMessage(response);
+    });
+};

--- a/web/src/audio/swingBufferCache.ts
+++ b/web/src/audio/swingBufferCache.ts
@@ -1,0 +1,65 @@
+import { DEFAULT_SWING_AMOUNT } from "./swingTiming";
+
+type CacheEntry = AudioBuffer | Promise<AudioBuffer>;
+
+const identityCache = new Map<string, CacheEntry>();
+const sourceBufferCache = new WeakMap<AudioBuffer, Map<string, CacheEntry>>();
+
+export function getSwingBufferCacheKey(
+  sourceBuffer: AudioBuffer,
+  sourceIdentity: string | null,
+  swingAmount = DEFAULT_SWING_AMOUNT,
+): string {
+  return [
+    sourceIdentity ?? "buffer",
+    "swing",
+    swingAmount,
+    sourceBuffer.sampleRate,
+    sourceBuffer.numberOfChannels,
+    sourceBuffer.length,
+  ].join(":");
+}
+
+export function getOrCreateSwingBuffer(
+  sourceBuffer: AudioBuffer,
+  sourceIdentity: string | null,
+  render: () => Promise<AudioBuffer>,
+  swingAmount = DEFAULT_SWING_AMOUNT,
+): Promise<AudioBuffer> {
+  const cacheKey = getSwingBufferCacheKey(
+    sourceBuffer,
+    sourceIdentity,
+    swingAmount,
+  );
+  const cache = getCache(sourceBuffer, sourceIdentity);
+  const existing = cache.get(cacheKey);
+  if (existing) {
+    return Promise.resolve(existing);
+  }
+  const pending = render()
+    .then((buffer) => {
+      cache.set(cacheKey, buffer);
+      return buffer;
+    })
+    .catch((err: unknown) => {
+      cache.delete(cacheKey);
+      throw err;
+    });
+  cache.set(cacheKey, pending);
+  return pending;
+}
+
+function getCache(
+  sourceBuffer: AudioBuffer,
+  sourceIdentity: string | null,
+): Map<string, CacheEntry> {
+  if (sourceIdentity) {
+    return identityCache;
+  }
+  let cache = sourceBufferCache.get(sourceBuffer);
+  if (!cache) {
+    cache = new Map<string, CacheEntry>();
+    sourceBufferCache.set(sourceBuffer, cache);
+  }
+  return cache;
+}

--- a/web/src/audio/swingRenderer.test.ts
+++ b/web/src/audio/swingRenderer.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { renderSwingChannels } from "./swingRenderer";
+import type { TimeStretchAdapter } from "./timeStretch";
+
+class FakeStretchAdapter implements TimeStretchAdapter {
+  calls: Array<{ inputFrames: number; targetFrameCount: number }> = [];
+
+  async stretchSegment(
+    channels: Float32Array[],
+    _sampleRate: number,
+    targetFrameCount: number,
+  ): Promise<Float32Array[]> {
+    this.calls.push({
+      inputFrames: channels[0]?.length ?? 0,
+      targetFrameCount,
+    });
+    return channels.map((channel) => {
+      const stretched = new Float32Array(targetFrameCount);
+      for (let index = 0; index < targetFrameCount; index += 1) {
+        stretched[index] = channel[Math.min(index, channel.length - 1)] ?? 0;
+      }
+      return stretched;
+    });
+  }
+}
+
+describe("renderSwingChannels", () => {
+  it("copies audio outside beats and preserves total frame count", async () => {
+    const adapter = new FakeStretchAdapter();
+    const source = Float32Array.from({ length: 10 }, (_, index) => index);
+
+    const [rendered] = await renderSwingChannels(
+      [source],
+      10,
+      [{ start: 0.2, duration: 0.4 }],
+      { adapter },
+    );
+
+    expect(rendered).toHaveLength(source.length);
+    expect(rendered?.[0]).toBe(0);
+    expect(rendered?.[1]).toBe(1);
+    expect(rendered?.[6]).toBe(6);
+    expect(rendered?.[9]).toBe(9);
+  });
+
+  it("splits each beat into fixed swing target frame counts", async () => {
+    const adapter = new FakeStretchAdapter();
+    const source = Float32Array.from({ length: 100 }, (_, index) => index);
+
+    await renderSwingChannels(
+      [source],
+      100,
+      [{ start: 0, duration: 1 }],
+      { adapter },
+    );
+
+    expect(adapter.calls).toEqual([
+      { inputFrames: 50, targetFrameCount: 67 },
+      { inputFrames: 50, targetFrameCount: 33 },
+    ]);
+  });
+
+  it("renders all channels with the same output geometry", async () => {
+    const adapter = new FakeStretchAdapter();
+    const left = Float32Array.from({ length: 20 }, (_, index) => index);
+    const right = Float32Array.from({ length: 20 }, (_, index) => index + 100);
+
+    const rendered = await renderSwingChannels(
+      [left, right],
+      20,
+      [{ start: 0, duration: 1 }],
+      { adapter },
+    );
+
+    expect(rendered).toHaveLength(2);
+    expect(rendered[0]).toHaveLength(20);
+    expect(rendered[1]).toHaveLength(20);
+    expect(adapter.calls).toEqual([
+      { inputFrames: 10, targetFrameCount: 13 },
+      { inputFrames: 10, targetFrameCount: 7 },
+    ]);
+  });
+
+  it("reports progress as beat segments complete", async () => {
+    const adapter = new FakeStretchAdapter();
+    const progress: number[] = [];
+    const source = Float32Array.from({ length: 20 }, (_, index) => index);
+
+    await renderSwingChannels(
+      [source],
+      10,
+      [
+        { start: 0, duration: 1 },
+        { start: 1, duration: 1 },
+      ],
+      {
+        adapter,
+        onProgress: (value) => progress.push(value),
+      },
+    );
+
+    expect(progress).toEqual([0, 0.25, 0.5, 0.75, 1, 1]);
+  });
+
+  it("applies a tiny equal-power envelope around rendered joins", async () => {
+    const adapter = new FakeStretchAdapter();
+    const source = Float32Array.from({ length: 100 }, () => 1);
+
+    const [rendered] = await renderSwingChannels(
+      [source],
+      1000,
+      [{ start: 0, duration: 0.1 }],
+      { adapter },
+    );
+
+    expect(rendered?.[62]).toBe(1);
+    expect(rendered?.[66]).toBeLessThan(1);
+    expect(rendered?.[67]).toBeLessThan(1);
+    expect(rendered?.[71]).toBe(1);
+  });
+});

--- a/web/src/audio/swingRenderer.ts
+++ b/web/src/audio/swingRenderer.ts
@@ -1,0 +1,295 @@
+import { RubberBandWorkerAdapter } from "./rubberBandAdapter";
+import {
+  DEFAULT_SWING_AMOUNT,
+  getSwingSegmentsForBeat,
+  type BeatLike,
+} from "./swingTiming";
+import type { TimeStretchAdapter } from "./timeStretch";
+
+export type RenderSwingOptions = {
+  adapter?: TimeStretchAdapter;
+  signal?: AbortSignal;
+  swingAmount?: number;
+  onProgress?: (progress: number) => void;
+};
+
+type FrameSegment = {
+  inputStartFrame: number;
+  inputFrameCount: number;
+  outputStartFrame: number;
+  outputFrameCount: number;
+};
+
+const JOIN_FADE_SECONDS = 0.004;
+const MAX_JOIN_FADE_FRACTION = 0.25;
+
+export async function renderSwingBuffer(
+  sourceBuffer: AudioBuffer,
+  beats: BeatLike[],
+  options: RenderSwingOptions = {},
+): Promise<AudioBuffer> {
+  const sourceChannels = Array.from(
+    { length: sourceBuffer.numberOfChannels },
+    (_, channelIndex) =>
+      new Float32Array(sourceBuffer.getChannelData(channelIndex)),
+  );
+  const renderedChannels = await renderSwingChannels(
+    sourceChannels,
+    sourceBuffer.sampleRate,
+    beats,
+    options,
+  );
+  throwIfAborted(options.signal);
+  const renderedBuffer = new AudioBuffer({
+    length: sourceBuffer.length,
+    numberOfChannels: sourceBuffer.numberOfChannels,
+    sampleRate: sourceBuffer.sampleRate,
+  });
+  renderedChannels.forEach((channel, channelIndex) => {
+    renderedBuffer.copyToChannel(
+      channel as Float32Array<ArrayBuffer>,
+      channelIndex,
+    );
+  });
+  return renderedBuffer;
+}
+
+export async function renderSwingChannels(
+  sourceChannels: Float32Array[],
+  sampleRate: number,
+  beats: BeatLike[],
+  options: RenderSwingOptions = {},
+): Promise<Float32Array[]> {
+  const sourceLength = sourceChannels[0]?.length ?? 0;
+  const outputChannels = sourceChannels.map((channel) => new Float32Array(channel));
+  if (sourceLength === 0 || sourceChannels.length === 0) {
+    return outputChannels;
+  }
+
+  const shouldDisposeAdapter = !options.adapter;
+  const adapter: TimeStretchAdapter =
+    options.adapter ?? new RubberBandWorkerAdapter();
+  const beatSegments = beats
+    .map((beat) =>
+      getBeatFrameSegments(
+        beat,
+        sampleRate,
+        sourceLength,
+        options.swingAmount ?? DEFAULT_SWING_AMOUNT,
+      ),
+    )
+    .filter((segments): segments is [FrameSegment, FrameSegment] =>
+      segments !== null,
+    );
+  const totalSegments = beatSegments.length * 2;
+  let completedSegments = 0;
+  options.onProgress?.(0);
+  try {
+    for (let beatIndex = 0; beatIndex < beatSegments.length; beatIndex += 1) {
+      const segments = beatSegments[beatIndex] as [FrameSegment, FrameSegment];
+      throwIfAborted(options.signal);
+      for (const segment of segments) {
+        throwIfAborted(options.signal);
+        const inputChannels = sourceChannels.map((channel) =>
+          channel.slice(
+            segment.inputStartFrame,
+            segment.inputStartFrame + segment.inputFrameCount,
+          ),
+        );
+        const stretched = await adapter.stretchSegment(
+          inputChannels,
+          sampleRate,
+          segment.outputFrameCount,
+        );
+        writeSegment(outputChannels, stretched, segment.outputStartFrame);
+        completedSegments += 1;
+        options.onProgress?.(
+          totalSegments > 0 ? completedSegments / totalSegments : 1,
+        );
+      }
+      applyJoinFade(
+        outputChannels,
+        segments[1].outputStartFrame,
+        sampleRate,
+        segments[0].outputFrameCount,
+        segments[1].outputFrameCount,
+      );
+      applyBeatBoundaryFades(outputChannels, beatSegments, beatIndex, sampleRate);
+    }
+    options.onProgress?.(1);
+    return outputChannels;
+  } finally {
+    if (shouldDisposeAdapter && adapter instanceof RubberBandWorkerAdapter) {
+      adapter.dispose();
+    }
+  }
+}
+
+function applyBeatBoundaryFades(
+  outputChannels: Float32Array[],
+  beatSegments: Array<[FrameSegment, FrameSegment]>,
+  beatIndex: number,
+  sampleRate: number,
+) {
+  const segments = beatSegments[beatIndex];
+  if (!segments) {
+    return;
+  }
+  const beatStartFrame = segments[0].outputStartFrame;
+  const beatFrameCount = segments[0].outputFrameCount + segments[1].outputFrameCount;
+  const previousSegments = beatSegments[beatIndex - 1];
+  const nextSegments = beatSegments[beatIndex + 1];
+  const hasContiguousPreviousBeat =
+    previousSegments !== undefined &&
+    previousSegments[0].outputStartFrame +
+      previousSegments[0].outputFrameCount +
+      previousSegments[1].outputFrameCount ===
+      beatStartFrame;
+  const hasContiguousNextBeat =
+    nextSegments !== undefined &&
+    beatStartFrame + beatFrameCount === nextSegments[0].outputStartFrame;
+
+  if (hasContiguousPreviousBeat) {
+    applyJoinFade(
+      outputChannels,
+      beatStartFrame,
+      sampleRate,
+      previousSegments[0].outputFrameCount + previousSegments[1].outputFrameCount,
+      beatFrameCount,
+    );
+  } else if (beatStartFrame > 0) {
+    applyJoinFade(
+      outputChannels,
+      beatStartFrame,
+      sampleRate,
+      beatStartFrame,
+      beatFrameCount,
+    );
+  }
+
+  if (hasContiguousNextBeat) {
+    return;
+  }
+  const remainingFrameCount =
+    (outputChannels[0]?.length ?? 0) - (beatStartFrame + beatFrameCount);
+  if (remainingFrameCount > 0) {
+    applyJoinFade(
+      outputChannels,
+      beatStartFrame + beatFrameCount,
+      sampleRate,
+      beatFrameCount,
+      remainingFrameCount,
+    );
+  }
+}
+
+function applyJoinFade(
+  outputChannels: Float32Array[],
+  boundaryFrame: number,
+  sampleRate: number,
+  previousFrameCount: number,
+  nextFrameCount: number,
+) {
+  const outputLength = outputChannels[0]?.length ?? 0;
+  if (
+    boundaryFrame <= 0 ||
+    boundaryFrame >= outputLength ||
+    previousFrameCount <= 0 ||
+    nextFrameCount <= 0
+  ) {
+    return;
+  }
+  const fadeFrames = Math.max(
+    1,
+    Math.min(
+      Math.round(JOIN_FADE_SECONDS * sampleRate),
+      Math.floor(previousFrameCount * MAX_JOIN_FADE_FRACTION),
+      Math.floor(nextFrameCount * MAX_JOIN_FADE_FRACTION),
+      boundaryFrame,
+      outputLength - boundaryFrame,
+    ),
+  );
+  if (fadeFrames <= 1) {
+    return;
+  }
+  const startFrame = boundaryFrame - fadeFrames;
+  outputChannels.forEach((outputChannel) => {
+    for (let index = 0; index < fadeFrames; index += 1) {
+      const t = (index + 1) / (fadeFrames + 1);
+      const fadeOut = Math.cos((t * Math.PI) / 2);
+      const fadeIn = Math.sin((t * Math.PI) / 2);
+      const outFrame = startFrame + index;
+      const inFrame = boundaryFrame + index;
+      outputChannel[outFrame] = (outputChannel[outFrame] ?? 0) * fadeOut;
+      outputChannel[inFrame] = (outputChannel[inFrame] ?? 0) * fadeIn;
+    }
+  });
+}
+
+function getBeatFrameSegments(
+  beat: BeatLike,
+  sampleRate: number,
+  sourceLength: number,
+  swingAmount: number,
+): [FrameSegment, FrameSegment] | null {
+  const beatStartFrame = Math.round(beat.start * sampleRate);
+  const beatEndFrame = Math.round((beat.start + beat.duration) * sampleRate);
+  if (
+    beatStartFrame < 0 ||
+    beatEndFrame > sourceLength ||
+    beatEndFrame - beatStartFrame < 2
+  ) {
+    return null;
+  }
+
+  const beatFrameCount = beatEndFrame - beatStartFrame;
+  const inputAFrameCount = Math.floor(beatFrameCount / 2);
+  const inputBFrameCount = beatFrameCount - inputAFrameCount;
+  const [segmentA] = getSwingSegmentsForBeat(beat, swingAmount);
+  const outputAFrameCount = Math.max(
+    1,
+    Math.min(
+      beatFrameCount - 1,
+      Math.round(segmentA.outputDuration * sampleRate),
+    ),
+  );
+  const outputBFrameCount = beatFrameCount - outputAFrameCount;
+
+  return [
+    {
+      inputStartFrame: beatStartFrame,
+      inputFrameCount: inputAFrameCount,
+      outputStartFrame: beatStartFrame,
+      outputFrameCount: outputAFrameCount,
+    },
+    {
+      inputStartFrame: beatStartFrame + inputAFrameCount,
+      inputFrameCount: inputBFrameCount,
+      outputStartFrame: beatStartFrame + outputAFrameCount,
+      outputFrameCount: outputBFrameCount,
+    },
+  ];
+}
+
+function writeSegment(
+  outputChannels: Float32Array[],
+  stretchedChannels: Float32Array[],
+  outputStartFrame: number,
+) {
+  outputChannels.forEach((outputChannel, channelIndex) => {
+    const stretched = stretchedChannels[channelIndex];
+    if (!stretched) {
+      return;
+    }
+    outputChannel.set(
+      stretched.subarray(0, outputChannel.length - outputStartFrame),
+      outputStartFrame,
+    );
+  });
+}
+
+function throwIfAborted(signal: AbortSignal | undefined) {
+  if (signal?.aborted) {
+    throw new DOMException("Swing rendering was cancelled", "AbortError");
+  }
+}

--- a/web/src/audio/swingTiming.test.ts
+++ b/web/src/audio/swingTiming.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampSwingAmount,
+  DEFAULT_SWING_AMOUNT,
+  getSwingSegmentsForBeat,
+} from "./swingTiming";
+
+describe("swing timing", () => {
+  it("uses 0.33 as the default swing amount", () => {
+    expect(DEFAULT_SWING_AMOUNT).toBe(0.33);
+  });
+
+  it("clamps swing amount defensively", () => {
+    expect(clampSwingAmount(2)).toBe(0.9);
+    expect(clampSwingAmount(-2)).toBe(-0.9);
+    expect(clampSwingAmount(Number.NaN)).toBe(DEFAULT_SWING_AMOUNT);
+  });
+
+  it("splits a 1 second beat into default swing output durations", () => {
+    const [first, second] = getSwingSegmentsForBeat({
+      start: 10,
+      duration: 1,
+    });
+
+    expect(first.outputDuration).toBeCloseTo(0.665, 12);
+    expect(second.outputDuration).toBeCloseTo(0.335, 12);
+    expect(first.outputDuration + second.outputDuration).toBeCloseTo(1, 12);
+  });
+
+  it("calculates playback rates as input duration over output duration", () => {
+    const [first, second] = getSwingSegmentsForBeat({
+      start: 0,
+      duration: 1,
+    });
+
+    expect(first.playbackRate).toBeCloseTo(first.inputDuration / first.outputDuration);
+    expect(second.playbackRate).toBeCloseTo(second.inputDuration / second.outputDuration);
+  });
+
+  it("lines up segment input starts and durations", () => {
+    const [first, second] = getSwingSegmentsForBeat({
+      start: 4,
+      duration: 2,
+    });
+
+    expect(first.inputStart).toBe(4);
+    expect(first.inputDuration).toBe(1);
+    expect(second.inputStart).toBe(5);
+    expect(second.inputDuration).toBe(1);
+  });
+});

--- a/web/src/audio/swingTiming.ts
+++ b/web/src/audio/swingTiming.ts
@@ -1,0 +1,52 @@
+export const DEFAULT_SWING_AMOUNT = 0.33;
+
+const MIN_SWING_AMOUNT = -0.9;
+const MAX_SWING_AMOUNT = 0.9;
+
+export type BeatLike = {
+  start: number;
+  duration: number;
+};
+
+export type SwingSegment = {
+  inputStart: number;
+  inputDuration: number;
+  outputDuration: number;
+  playbackRate: number;
+};
+
+export function clampSwingAmount(swingAmount: number): number {
+  if (!Number.isFinite(swingAmount)) {
+    return DEFAULT_SWING_AMOUNT;
+  }
+  return Math.max(MIN_SWING_AMOUNT, Math.min(MAX_SWING_AMOUNT, swingAmount));
+}
+
+export function getSwingSegmentsForBeat(
+  beat: BeatLike,
+  swingAmount = DEFAULT_SWING_AMOUNT,
+): [SwingSegment, SwingSegment] {
+  const duration = Math.max(0, beat.duration);
+  const half = duration / 2;
+  const swing = clampSwingAmount(swingAmount);
+
+  const outputADuration = half * (1 + swing);
+  const outputBDuration = duration - outputADuration;
+  const safeOutputADuration = Math.max(Number.EPSILON, outputADuration);
+  const safeOutputBDuration = Math.max(Number.EPSILON, outputBDuration);
+
+  return [
+    {
+      inputStart: beat.start,
+      inputDuration: half,
+      outputDuration: outputADuration,
+      playbackRate: half / safeOutputADuration,
+    },
+    {
+      inputStart: beat.start + half,
+      inputDuration: half,
+      outputDuration: outputBDuration,
+      playbackRate: half / safeOutputBDuration,
+    },
+  ];
+}

--- a/web/src/audio/timeStretch.ts
+++ b/web/src/audio/timeStretch.ts
@@ -1,0 +1,7 @@
+export interface TimeStretchAdapter {
+  stretchSegment(
+    channels: Float32Array[],
+    sampleRate: number,
+    targetFrameCount: number,
+  ): Promise<Float32Array[]>;
+}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Adds Swing extra mode for jukebox playback. Swing pre-renders a pitch-preserved swung buffer in the browser using Rubber Band WASM, shows progress while preparing, then plays through the existing jukebox engine with normal beat/jump timing preserved.
- Inspired from: Echo Nest Remix's [Swinger](https://github.com/echonest/remix/blob/master/examples/swinger/swinger.py) script.