### PR TITLE
User selected anchor branch

### DIFF
--- a/pwa/src/app/routes/Listen.test.tsx
+++ b/pwa/src/app/routes/Listen.test.tsx
@@ -29,6 +29,8 @@ type MockPlayerInstance = {
 const playerInstances: MockPlayerInstance[] = [];
 type MockJukeboxControllerInstance = {
   emitEdgeSelect: (edge: unknown) => void;
+  setData: ReturnType<typeof vi.fn>;
+  setSelectedEdgeActive: ReturnType<typeof vi.fn>;
 };
 const jukeboxControllerInstances: MockJukeboxControllerInstance[] = [];
 type MockEngineInstance = {
@@ -36,6 +38,8 @@ type MockEngineInstance = {
   syncToPlaybackPosition: ReturnType<typeof vi.fn>;
   startJukebox: ReturnType<typeof vi.fn>;
   play: ReturnType<typeof vi.fn>;
+  setUserAnchorEdge: ReturnType<typeof vi.fn>;
+  getUserAnchorEdgeId: ReturnType<typeof vi.fn>;
 };
 const engineInstances: MockEngineInstance[] = [];
 
@@ -205,6 +209,8 @@ vi.mock("@/shared/jukebox/engine", () => ({
     seekToBeat = vi.fn();
     setForceBranch = vi.fn();
     setBringItHomeMode = vi.fn();
+    setUserAnchorEdge = vi.fn();
+    getUserAnchorEdgeId = vi.fn(() => null);
     deleteEdge = vi.fn();
     rebuildGraph = vi.fn();
     clearDeletedEdges = vi.fn();
@@ -252,13 +258,13 @@ vi.mock("@/shared/jukebox/viz/JukeboxController", () => ({
     setAnchorHighlightEnabled(_enabled: boolean) {}
     resizeActive() {}
     reset() {}
-    setData(_data: unknown) {}
+    setData = vi.fn((_data: unknown) => {});
     setOnSelect(_handler: (index: number) => void) {}
     setOnEdgeSelect(handler: (edge: unknown) => void) {
       this.onEdgeSelect = handler;
     }
     setSelectedEdge(_edge: unknown) {}
-    setSelectedEdgeActive(_edge: unknown) {}
+    setSelectedEdgeActive = vi.fn((_edge: unknown) => {});
     update(_index: number, _animate: boolean, _jumpFrom: number | null) {}
     destroy() {}
     getCount() {
@@ -729,6 +735,68 @@ describe("Listen route behavior", () => {
     );
     expect(tuningPanel.classList.contains("hidden")).toBe(true);
     expect(extrasPanel.classList.contains("hidden")).toBe(false);
+    rendered.unmount();
+  });
+
+  it("sets and clears the selected backward branch as the user anchor with A", async () => {
+    const rendered = renderListen();
+    await settleEffects();
+
+    const controller = jukeboxControllerInstances[0];
+    const engine = engineInstances[0];
+    if (!controller || !engine) {
+      throw new Error("Expected jukebox controller and engine instances");
+    }
+    const edge = {
+      id: 7,
+      deleted: false,
+      src: { start: 12, which: 12 },
+      dest: { start: 4, which: 4 },
+      distance: 8,
+    };
+    controller.setData.mockClear();
+    controller.setSelectedEdgeActive.mockClear();
+    await act(async () => {
+      controller.emitEdgeSelect(edge);
+    });
+
+    await keydown("A", "KeyA");
+
+    expect(engine.setUserAnchorEdge).toHaveBeenCalledWith(edge);
+    expect(controller.setData).toHaveBeenCalled();
+    expect(controller.setSelectedEdgeActive).toHaveBeenCalledWith(edge);
+    expect(rendered.container.textContent).toContain("Anchor branch set");
+
+    engine.getUserAnchorEdgeId.mockReturnValue(edge.id);
+    await keydown("a", "KeyA");
+
+    expect(engine.setUserAnchorEdge).toHaveBeenLastCalledWith(null);
+    expect(rendered.container.textContent).toContain("Anchor branch reset");
+    rendered.unmount();
+  });
+
+  it("ignores A for a selected forward branch", async () => {
+    const rendered = renderListen();
+    await settleEffects();
+
+    const controller = jukeboxControllerInstances[0];
+    const engine = engineInstances[0];
+    if (!controller || !engine) {
+      throw new Error("Expected jukebox controller and engine instances");
+    }
+    await act(async () => {
+      controller.emitEdgeSelect({
+        id: 8,
+        deleted: false,
+        src: { start: 4, which: 4 },
+        dest: { start: 12, which: 12 },
+        distance: 8,
+      });
+    });
+
+    await keydown("A", "KeyA");
+
+    expect(engine.setUserAnchorEdge).not.toHaveBeenCalled();
     rendered.unmount();
   });
 

--- a/pwa/src/app/routes/Listen.tsx
+++ b/pwa/src/app/routes/Listen.tsx
@@ -772,6 +772,16 @@ export function Listen({ isActive = true }: { isActive?: boolean }) {
       }
       if (
         playMode === "jukebox" &&
+        (event.key === "a" || event.key === "A") &&
+        !event.repeat
+      ) {
+        if (toggleSelectedAnchorBranch()) {
+          event.preventDefault();
+        }
+        return;
+      }
+      if (
+        playMode === "jukebox" &&
         event.key === "Shift" &&
         isRunning &&
         !bringItHomeModeRef.current
@@ -1320,6 +1330,20 @@ export function Listen({ isActive = true }: { isActive?: boolean }) {
     const nextEdge = edges[nextIndex];
     setSelectedEdge(nextEdge);
     vizControllerRef.current?.setSelectedEdgeActive(nextEdge);
+  };
+
+  const toggleSelectedAnchorBranch = () => {
+    const engine = engineRef.current;
+    const edge = selectedEdge;
+    if (!engine || !edge || edge.deleted || edge.dest.which >= edge.src.which) {
+      return false;
+    }
+    const nextAnchor = engine.getUserAnchorEdgeId() === edge.id ? null : edge;
+    engine.setUserAnchorEdge(nextAnchor);
+    syncVizDataFromEngine();
+    vizControllerRef.current?.setSelectedEdgeActive(edge);
+    showShortcutToast(nextAnchor ? "Anchor branch set" : "Anchor branch reset");
+    return true;
   };
 
   const onApplyTuning = () => {
@@ -2363,6 +2387,10 @@ export function Listen({ isActive = true }: { isActive?: boolean }) {
               <div className="info-row">
                 <span className="info-label">Left/Right:</span>
                 <span>Cycle selected branch</span>
+              </div>
+              <div className="info-row">
+                <span className="info-label">A:</span>
+                <span>Set/reset selected anchor branch</span>
               </div>
               <div className="info-row">
                 <span className="info-label">Delete:</span>

--- a/pwa/src/shared/jukebox/engine/JukeboxEngine.test.ts
+++ b/pwa/src/shared/jukebox/engine/JukeboxEngine.test.ts
@@ -263,6 +263,7 @@ describe("PWA JukeboxEngine jump scheduling parity", () => {
 
     expect(engine.getUserAnchorEdgeId()).toBe(userEdge.id);
     expect(engine.getVisualizationData()?.anchorEdgeId).toBe(userEdge.id);
+    expect(engine.getVisualizationData()?.userAnchorEdgeId).toBe(userEdge.id);
 
     engineAny.currentBeatIndex = 0;
     engineAny.nextAudioTime = 1;
@@ -281,6 +282,7 @@ describe("PWA JukeboxEngine jump scheduling parity", () => {
     engine.setUserAnchorEdge(null);
     expect(engine.getUserAnchorEdgeId()).toBeNull();
     expect(engine.getVisualizationData()?.anchorEdgeId).toBe(defaultEdge.id);
+    expect(engine.getVisualizationData()?.userAnchorEdgeId).toBeNull();
   });
 
   it("falls back to the default anchor when the user anchor is deleted", () => {
@@ -320,6 +322,7 @@ describe("PWA JukeboxEngine jump scheduling parity", () => {
 
     expect(engine.getUserAnchorEdgeId()).toBeNull();
     expect(engine.getVisualizationData()?.anchorEdgeId).toBe(defaultEdge.id);
+    expect(engine.getVisualizationData()?.userAnchorEdgeId).toBeNull();
   });
 
   it("does not take forward branches that skip past a user-selected anchor", () => {

--- a/pwa/src/shared/jukebox/engine/JukeboxEngine.test.ts
+++ b/pwa/src/shared/jukebox/engine/JukeboxEngine.test.ts
@@ -216,4 +216,162 @@ describe("PWA JukeboxEngine jump scheduling parity", () => {
 
     expect(engineAny.branchState.lastDestBySource).toBeNull();
   });
+
+  it("uses a user-selected anchor edge for visualization and forced anchor jumps", () => {
+    const player = makePlayer();
+    const engine = new JukeboxEngine(player, {
+      randomMode: "seeded",
+      seed: 1,
+      config: {
+        minRandomBranchChance: 0,
+        maxRandomBranchChance: 0,
+        randomBranchChanceDelta: 0,
+      },
+    });
+    const beats = [0, 1, 2, 3].map(makeBeat);
+    linkBeats(beats);
+    const defaultEdge: Edge = {
+      id: 1,
+      src: beats[1],
+      dest: beats[0],
+      distance: 10,
+      deleted: false,
+    };
+    const userEdge: Edge = {
+      id: 3,
+      src: beats[3],
+      dest: beats[0],
+      distance: 5,
+      deleted: false,
+    };
+    beats[1].neighbors = [defaultEdge];
+    beats[1].allNeighbors = [defaultEdge];
+    beats[3].neighbors = [userEdge];
+    beats[3].allNeighbors = [userEdge];
+    const graph: JukeboxGraphState = {
+      computedThreshold: 0,
+      currentThreshold: 0,
+      lastBranchPoint: 1,
+      totalBeats: beats.length,
+      longestReach: 0,
+      allEdges: [defaultEdge, userEdge],
+    };
+    const engineAny = installEngineState(engine, beats, graph, 0, 1);
+
+    expect(engine.getVisualizationData()?.anchorEdgeId).toBe(defaultEdge.id);
+    engine.setUserAnchorEdge(userEdge);
+
+    expect(engine.getUserAnchorEdgeId()).toBe(userEdge.id);
+    expect(engine.getVisualizationData()?.anchorEdgeId).toBe(userEdge.id);
+
+    engineAny.currentBeatIndex = 0;
+    engineAny.nextAudioTime = 1;
+    engineAny.advanceBeat(engineAny.nextAudioTime);
+
+    expect(engineAny.currentBeatIndex).toBe(1);
+    expect(player.scheduleJump).not.toHaveBeenCalled();
+
+    engineAny.currentBeatIndex = 2;
+    engineAny.nextAudioTime = 3;
+    engineAny.advanceBeat(engineAny.nextAudioTime);
+
+    expect(engineAny.currentBeatIndex).toBe(0);
+    expect(player.scheduleJump).toHaveBeenCalledWith(0, 3);
+
+    engine.setUserAnchorEdge(null);
+    expect(engine.getUserAnchorEdgeId()).toBeNull();
+    expect(engine.getVisualizationData()?.anchorEdgeId).toBe(defaultEdge.id);
+  });
+
+  it("falls back to the default anchor when the user anchor is deleted", () => {
+    const engine = new JukeboxEngine(makePlayer());
+    const beats = [0, 1, 2, 3].map(makeBeat);
+    linkBeats(beats);
+    const defaultEdge: Edge = {
+      id: 1,
+      src: beats[3],
+      dest: beats[0],
+      distance: 10,
+      deleted: false,
+    };
+    const userEdge: Edge = {
+      id: 2,
+      src: beats[2],
+      dest: beats[0],
+      distance: 5,
+      deleted: false,
+    };
+    beats[3].neighbors = [defaultEdge];
+    beats[3].allNeighbors = [defaultEdge];
+    beats[2].neighbors = [userEdge];
+    beats[2].allNeighbors = [userEdge];
+    const graph: JukeboxGraphState = {
+      computedThreshold: 0,
+      currentThreshold: 0,
+      lastBranchPoint: 3,
+      totalBeats: beats.length,
+      longestReach: 0,
+      allEdges: [defaultEdge, userEdge],
+    };
+    installEngineState(engine, beats, graph, 0, 1);
+
+    engine.setUserAnchorEdge(userEdge);
+    engine.deleteEdge(userEdge);
+
+    expect(engine.getUserAnchorEdgeId()).toBeNull();
+    expect(engine.getVisualizationData()?.anchorEdgeId).toBe(defaultEdge.id);
+  });
+
+  it("does not take forward branches that skip past a user-selected anchor", () => {
+    const player = makePlayer();
+    const engine = new JukeboxEngine(player, {
+      config: {
+        minRandomBranchChance: 1,
+        maxRandomBranchChance: 1,
+        randomBranchChanceDelta: 0,
+      },
+    });
+    const beats = [0, 1, 2, 3, 4, 5].map(makeBeat);
+    linkBeats(beats);
+    const safeEdge: Edge = {
+      id: 1,
+      src: beats[1],
+      dest: beats[0],
+      distance: 100,
+      deleted: false,
+    };
+    const skipPastAnchorEdge: Edge = {
+      id: 2,
+      src: beats[1],
+      dest: beats[5],
+      distance: 1,
+      deleted: false,
+    };
+    const userAnchorEdge: Edge = {
+      id: 3,
+      src: beats[4],
+      dest: beats[0],
+      distance: 1,
+      deleted: false,
+    };
+    beats[1].neighbors = [skipPastAnchorEdge, safeEdge];
+    beats[1].allNeighbors = [skipPastAnchorEdge, safeEdge];
+    beats[4].neighbors = [userAnchorEdge];
+    beats[4].allNeighbors = [userAnchorEdge];
+    const graph: JukeboxGraphState = {
+      computedThreshold: 0,
+      currentThreshold: 0,
+      lastBranchPoint: 4,
+      totalBeats: beats.length,
+      longestReach: 0,
+      allEdges: [safeEdge, skipPastAnchorEdge, userAnchorEdge],
+    };
+    const engineAny = installEngineState(engine, beats, graph, 0, 1);
+    engine.setUserAnchorEdge(userAnchorEdge);
+
+    engineAny.advanceBeat(engineAny.nextAudioTime);
+
+    expect(engineAny.currentBeatIndex).toBe(0);
+    expect(player.scheduleJump).toHaveBeenCalledWith(0, 1);
+  });
 });

--- a/pwa/src/shared/jukebox/engine/JukeboxEngine.ts
+++ b/pwa/src/shared/jukebox/engine/JukeboxEngine.ts
@@ -184,12 +184,19 @@ export class JukeboxEngine {
         }
       }
     }
-    const anchorEdgeId = this.getActiveAnchorEdge()?.id ?? null;
+    const userAnchorEdge = this.getUserAnchorEdge();
+    const defaultAnchorEdge = this.getDefaultAnchorEdge();
+    const anchorEdgeId = userAnchorEdge?.id ?? defaultAnchorEdge?.id ?? null;
+    const userAnchorEdgeId =
+      userAnchorEdge && userAnchorEdge.id !== defaultAnchorEdge?.id
+        ? userAnchorEdge.id
+        : null;
     return {
       beats: this.beats,
       edges: Array.from(edgeMap.values()),
       lastBranchPoint: this.graph.lastBranchPoint,
       anchorEdgeId,
+      userAnchorEdgeId,
     };
   }
 
@@ -350,10 +357,6 @@ export class JukeboxEngine {
     const bestIndex = getBestLastBranchNeighborIndex(anchorSource);
     const bestEdge = anchorSource.neighbors[bestIndex];
     return bestEdge && !bestEdge.deleted ? bestEdge : null;
-  }
-
-  private getActiveAnchorEdge(): Edge | null {
-    return this.getUserAnchorEdge() ?? this.getDefaultAnchorEdge();
   }
 
   private ensureAnchorSourceHasNeighbors() {

--- a/pwa/src/shared/jukebox/engine/JukeboxEngine.ts
+++ b/pwa/src/shared/jukebox/engine/JukeboxEngine.ts
@@ -9,8 +9,10 @@ import {
   BranchState,
   getBestLastBranchNeighborIndex,
   selectNextBeatIndex,
+  UserAnchorSelection,
 } from "./selection";
 import {
+  Edge,
   JukeboxConfig,
   JukeboxGraphState,
   JukeboxState,
@@ -83,6 +85,7 @@ export class JukeboxEngine {
   private bringItHomeMode = false;
   private pendingAdvance: PendingAdvance | null = null;
   private deletedEdgeKeys = new Set<string>();
+  private userAnchorEdgeId: number | null = null;
   private rng: () => number;
   private listener: UpdateListener | null = null;
   private branchState: BranchState = {
@@ -122,6 +125,7 @@ export class JukeboxEngine {
 
   loadAnalysis(data: unknown) {
     this.deletedEdgeKeys.clear();
+    this.userAnchorEdgeId = null;
     this.analysis = normalizeAnalysis(data);
     this.config.minLongBranch = Math.floor(this.analysis.beats.length / 5);
     this.graph = buildJumpGraph(this.analysis, this.config);
@@ -140,6 +144,15 @@ export class JukeboxEngine {
 
   updateConfig(partial: Partial<JukeboxConfig>) {
     this.config = { ...this.config, ...partial };
+  }
+
+  setUserAnchorEdge(edge: Edge | null) {
+    this.userAnchorEdgeId = edge ? edge.id : null;
+    this.clearPendingAdvance(true);
+  }
+
+  getUserAnchorEdgeId(): number | null {
+    return this.getUserAnchorEdge()?.id ?? null;
   }
 
   rebuildGraph() {
@@ -171,15 +184,7 @@ export class JukeboxEngine {
         }
       }
     }
-    let anchorEdgeId: number | null = null;
-    const anchorSource = this.beats[this.graph.lastBranchPoint];
-    if (anchorSource && anchorSource.neighbors.length > 0) {
-      const bestIndex = getBestLastBranchNeighborIndex(anchorSource);
-      const bestEdge = anchorSource.neighbors[bestIndex];
-      if (bestEdge && !bestEdge.deleted) {
-        anchorEdgeId = bestEdge.id;
-      }
-    }
+    const anchorEdgeId = this.getActiveAnchorEdge()?.id ?? null;
     return {
       beats: this.beats,
       edges: Array.from(edgeMap.values()),
@@ -264,6 +269,7 @@ export class JukeboxEngine {
 
   clearDeletedEdges() {
     this.deletedEdgeKeys.clear();
+    this.userAnchorEdgeId = null;
     this.clearPendingAdvance(true);
     this.clearEdgeDeletionFlags();
   }
@@ -311,6 +317,43 @@ export class JukeboxEngine {
       beat.neighbors = beat.neighbors.filter((edge) => !edge.deleted);
     }
     this.ensureAnchorSourceHasNeighbors();
+  }
+
+  private getActiveUserAnchorSelection(): UserAnchorSelection | null {
+    const edge = this.getUserAnchorEdge();
+    return edge ? { edgeId: edge.id, sourceIndex: edge.src.which } : null;
+  }
+
+  private getUserAnchorEdge(): Edge | null {
+    if (!this.graph || this.userAnchorEdgeId === null) {
+      return null;
+    }
+    const edge = this.graph.allEdges.find(
+      (candidate) => candidate.id === this.userAnchorEdgeId,
+    );
+    if (!edge || edge.deleted) {
+      return null;
+    }
+    return edge.src.neighbors.some((candidate) => candidate.id === edge.id)
+      ? edge
+      : null;
+  }
+
+  private getDefaultAnchorEdge(): Edge | null {
+    if (!this.graph) {
+      return null;
+    }
+    const anchorSource = this.beats[this.graph.lastBranchPoint];
+    if (!anchorSource || anchorSource.neighbors.length === 0) {
+      return null;
+    }
+    const bestIndex = getBestLastBranchNeighborIndex(anchorSource);
+    const bestEdge = anchorSource.neighbors[bestIndex];
+    return bestEdge && !bestEdge.deleted ? bestEdge : null;
+  }
+
+  private getActiveAnchorEdge(): Edge | null {
+    return this.getUserAnchorEdge() ?? this.getDefaultAnchorEdge();
   }
 
   private ensureAnchorSourceHasNeighbors() {
@@ -512,6 +555,7 @@ export class JukeboxEngine {
           this.rng,
           this.branchState,
           this.forceBranch,
+          this.getActiveUserAnchorSelection(),
         );
         this.curRandomBranchChance = this.branchState.curRandomBranchChance;
         shouldJump = selection.jumped;

--- a/pwa/src/shared/jukebox/engine/selection.ts
+++ b/pwa/src/shared/jukebox/engine/selection.ts
@@ -5,6 +5,11 @@ export interface BranchState {
   lastDestBySource?: Map<number, number> | null;
 }
 
+export interface UserAnchorSelection {
+  edgeId: number;
+  sourceIndex: number;
+}
+
 const REFERENCE_BEAT_DURATION_SECONDS = 0.5;
 
 function collectTimeline(seed: QuantumBase): QuantumBase[] {
@@ -194,9 +199,10 @@ export function shouldRandomBranch(
   graph: JukeboxGraphState,
   config: JukeboxConfig,
   rng: () => number,
-  state: BranchState
+  state: BranchState,
+  suppressDefaultAnchor = false
 ): boolean {
-  if (q.which === graph.lastBranchPoint) {
+  if (!suppressDefaultAnchor && q.which === graph.lastBranchPoint) {
     return true;
   }
   // Gradually increase branch chance by elapsed musical time (not raw beat
@@ -225,21 +231,62 @@ export function selectNextBeatIndex(
   config: JukeboxConfig,
   rng: () => number,
   state: BranchState,
-  forceBranch = false
+  forceBranch = false,
+  userAnchor: UserAnchorSelection | null = null
 ): { index: number; jumped: boolean } {
   if (seed.neighbors.length === 0) {
     return { index: seed.which, jumped: false };
   }
-  if (!forceBranch && !shouldRandomBranch(seed, graph, config, rng, state)) {
+  const userAnchorIndex =
+    userAnchor === null
+      ? -1
+      : seed.neighbors.findIndex((edge) => edge.id === userAnchor.edgeId);
+  const candidateIndexes =
+    userAnchor !== null && seed.which < userAnchor.sourceIndex
+      ? seed.neighbors
+          .map((edge, index) =>
+            edge.dest.which < userAnchor.sourceIndex ? index : -1,
+          )
+          .filter((index) => index >= 0)
+      : undefined;
+  if (
+    userAnchorIndex < 0 &&
+    candidateIndexes?.length === 0
+  ) {
+    return { index: seed.which, jumped: false };
+  }
+  if (
+    userAnchorIndex < 0 &&
+    !forceBranch &&
+    !shouldRandomBranch(
+      seed,
+      graph,
+      config,
+      rng,
+      state,
+      userAnchor !== null,
+    )
+  ) {
     return { index: seed.which, jumped: false };
   }
   let nextEdge;
-  if (seed.which === graph.lastBranchPoint) {
+  if (userAnchorIndex >= 0) {
+    const selected = seed.neighbors.splice(userAnchorIndex, 1);
+    nextEdge = selected[0];
+  } else if (userAnchor === null && seed.which === graph.lastBranchPoint) {
     const bestIndex = getBestLastBranchNeighborIndex(seed);
     const selected = seed.neighbors.splice(bestIndex, 1);
     nextEdge = selected[0];
   } else {
-    const selectedIndex = selectWeightedNeighborIndex(seed, rng, state);
+    const selectedIndex = selectWeightedNeighborIndex(
+      seed,
+      rng,
+      state,
+      candidateIndexes,
+    );
+    if (selectedIndex < 0) {
+      return { index: seed.which, jumped: false };
+    }
     const selected = seed.neighbors.splice(selectedIndex, 1);
     nextEdge = selected[0];
   }
@@ -259,12 +306,16 @@ function selectWeightedNeighborIndex(
   seed: QuantumBase,
   rng: () => number,
   state: BranchState,
+  candidateIndexes?: number[],
 ): number {
-  if (seed.neighbors.length <= 1) {
-    return 0;
+  const indexes =
+    candidateIndexes ?? seed.neighbors.map((_edge, index) => index);
+  if (indexes.length <= 1) {
+    return indexes[0] ?? -1;
   }
   const lastDest = state.lastDestBySource?.get(seed.which);
-  const weights = seed.neighbors.map((edge) => {
+  const weights = indexes.map((index) => {
+    const edge = seed.neighbors[index];
     const distanceWeight = 1 / (1 + Math.max(0, edge.distance));
     const repeatPenalty =
       lastDest !== undefined && edge.dest.which === lastDest ? 0.35 : 1;
@@ -279,8 +330,8 @@ function selectWeightedNeighborIndex(
   for (let i = 0; i < weights.length; i += 1) {
     target -= weights[i];
     if (target <= 0) {
-      return i;
+      return indexes[i];
     }
   }
-  return weights.length - 1;
+  return indexes[indexes.length - 1] ?? -1;
 }

--- a/pwa/src/shared/jukebox/viz/JukeboxViz.test.ts
+++ b/pwa/src/shared/jukebox/viz/JukeboxViz.test.ts
@@ -190,4 +190,37 @@ describe("JukeboxViz", () => {
 
     expect(onEdgeSelect).toHaveBeenCalledWith(null);
   });
+
+  it("draws user-selected anchor highlight even when anchor highlighting is disabled", () => {
+    const viz = new JukeboxViz(createContainer());
+    const edge = {
+      id: 7,
+      src: { which: 0 },
+      dest: { which: 1 },
+      deleted: false,
+    };
+    viz.setData(
+      {
+        beats: [
+          { which: 0, start: 0, duration: 1 },
+          { which: 1, start: 1, duration: 1 },
+        ],
+        edges: [edge],
+        lastBranchPoint: 0,
+        anchorEdgeId: 7,
+        userAnchorEdgeId: 7,
+      } as any
+    );
+    const active = (viz as any).activeViz;
+    const drawEdge = vi.spyOn(active, "drawEdge");
+
+    active.drawBase();
+
+    expect(drawEdge).toHaveBeenCalledWith(
+      expect.anything(),
+      edge,
+      "#ff2d2d",
+      1.8,
+    );
+  });
 });

--- a/pwa/src/shared/jukebox/viz/JukeboxViz.ts
+++ b/pwa/src/shared/jukebox/viz/JukeboxViz.ts
@@ -21,6 +21,7 @@ interface VisualizationData {
   edges: Edge[];
   lastBranchPoint: number;
   anchorEdgeId: number | null;
+  userAnchorEdgeId: number | null;
 }
 
 const ANCHOR_HIGHLIGHT_COLOR = "#ff2d2d";
@@ -362,9 +363,12 @@ class CanvasViz {
       }
     }
 
-    if (this.anchorHighlightEnabled && this.data.anchorEdgeId !== null) {
+    const highlightedAnchorEdgeId =
+      this.data.userAnchorEdgeId ??
+      (this.anchorHighlightEnabled ? this.data.anchorEdgeId : null);
+    if (highlightedAnchorEdgeId !== null) {
       for (const edge of edges) {
-        if (edge.deleted || edge.id !== this.data.anchorEdgeId) {
+        if (edge.deleted || edge.id !== highlightedAnchorEdgeId) {
           continue;
         }
         this.drawEdge(this.baseCtx, edge, ANCHOR_HIGHLIGHT_COLOR, 1.8);

--- a/web/README.md
+++ b/web/README.md
@@ -41,6 +41,7 @@ data under storage pressure.
 - Shift (hold): force branches while the jukebox is playing.
 - H: toggle Bring It Home mode.
 - Left/Right: cycle selected branch.
+- A: set/reset the selected backward branch as the anchor branch.
 - Delete: remove a selected branch (click a branch in the visualization first).
 
 ## Analysis format (inferred)

--- a/web/index.html
+++ b/web/index.html
@@ -636,6 +636,10 @@
               Offline App (PWA) can now <strong>export audio</strong> with any
               actively selected Audio Mode.
             </li>
+            <li>
+              Added <strong>user-selected anchor branches</strong>: select a backward branch and press A to make it
+              the forced anchor jump.
+            </li>
           </ul>
 
           <h4>April 2026</h4>
@@ -969,6 +973,10 @@
             <div class="info-row">
               <span class="info-label">Left/Right:</span>
               <span>Cycle selected branch</span>
+            </div>
+            <div class="info-row">
+              <span class="info-label">A:</span>
+              <span>Set/reset selected anchor branch</span>
             </div>
             <div class="info-row">
               <span class="info-label">Delete:</span>

--- a/web/src/app/playback.test.ts
+++ b/web/src/app/playback.test.ts
@@ -19,6 +19,7 @@ import {
   updateVizVisibility,
   updateListenTimeDisplay,
 } from "./playback";
+import { createPlaybackUiHandlers } from "./wire/playback";
 import { setWindowUrl } from "./__tests__/test-utils";
 import { getOrCreateSwingBuffer } from "../audio/swingBufferCache";
 import { renderSwingBuffer } from "../audio/swingRenderer";
@@ -242,6 +243,7 @@ function createContext(overrides?: Partial<AppContext>): AppContext {
     justLongBranches: false,
     removeSequentialBranches: false,
   };
+  let userAnchorEdgeId: number | null = null;
   const engine = {
     getConfig: vi.fn(() => ({ ...engineConfig })),
     updateConfig: vi.fn((partial: Record<string, unknown>) => {
@@ -260,6 +262,10 @@ function createContext(overrides?: Partial<AppContext>): AppContext {
     seekToBeat: vi.fn(),
     setForceBranch: vi.fn(),
     setBringItHomeMode: vi.fn(),
+    setUserAnchorEdge: vi.fn((edge: { id: number } | null) => {
+      userAnchorEdgeId = edge ? edge.id : null;
+    }),
+    getUserAnchorEdgeId: vi.fn(() => userAnchorEdgeId),
     getSectionStartBeatIndices: vi.fn(() => []),
   };
   const player = {
@@ -291,6 +297,7 @@ function createContext(overrides?: Partial<AppContext>): AppContext {
     setData: vi.fn(),
     setAnchorHighlightEnabled: vi.fn(),
     setSelectedEdge: vi.fn(),
+    setSelectedEdgeActive: vi.fn(),
     resizeActive: vi.fn(),
     reset: vi.fn(),
     update: vi.fn(),
@@ -627,6 +634,100 @@ describe("playback tuning", () => {
     expect(graph.allEdges[0].deleted).toBe(true);
     expect(graph.allEdges[2].deleted).toBe(true);
     expect(context.state.deletedEdgeIds).toEqual([1, 3]);
+  });
+
+  it("applies anchor branch from url when analysis loads", () => {
+    setWindowUrl("http://localhost/listen/abc?ab=3");
+    const anchorEdge = {
+      id: 3,
+      deleted: false,
+      src: { which: 8 },
+      dest: { which: 2 },
+    };
+    const context = createContext({
+      engine: {
+        getConfig: vi.fn(() => ({
+          currentThreshold: 0,
+          minRandomBranchChance: 0.18,
+          maxRandomBranchChance: 0.5,
+          randomBranchChanceDelta: 0.02,
+          justBackwards: false,
+          justLongBranches: false,
+          removeSequentialBranches: false,
+        })),
+        updateConfig: vi.fn(),
+        loadAnalysis: vi.fn(),
+        getSectionStartBeatIndices: vi.fn(() => []),
+        getGraphState: vi.fn(() => ({
+          currentThreshold: 45,
+          allEdges: [anchorEdge],
+          totalBeats: 0,
+        })),
+        getVisualizationData: vi.fn(() => ({ beats: [], edges: [] })),
+        deleteEdge: vi.fn(),
+        rebuildGraph: vi.fn(),
+        setUserAnchorEdge: vi.fn(),
+        getUserAnchorEdgeId: vi.fn(() => 3),
+      } as unknown as AppContext["engine"],
+    });
+
+    const response: AnalysisComplete = {
+      status: "complete",
+      id: "job123",
+      result: { beats: [], track: {} },
+    };
+
+    const applied = applyAnalysisResult(context, response);
+
+    expect(applied).toBe(true);
+    expect(context.engine.setUserAnchorEdge).toHaveBeenCalledWith(anchorEdge);
+    expect(context.state.tuningParams).toContain("ab=3");
+  });
+
+  it("ignores forward anchor branch ids from url", () => {
+    setWindowUrl("http://localhost/listen/abc?ab=4");
+    const forwardEdge = {
+      id: 4,
+      deleted: false,
+      src: { which: 2 },
+      dest: { which: 8 },
+    };
+    const context = createContext({
+      engine: {
+        getConfig: vi.fn(() => ({
+          currentThreshold: 0,
+          minRandomBranchChance: 0.18,
+          maxRandomBranchChance: 0.5,
+          randomBranchChanceDelta: 0.02,
+          justBackwards: false,
+          justLongBranches: false,
+          removeSequentialBranches: false,
+        })),
+        updateConfig: vi.fn(),
+        loadAnalysis: vi.fn(),
+        getSectionStartBeatIndices: vi.fn(() => []),
+        getGraphState: vi.fn(() => ({
+          currentThreshold: 45,
+          allEdges: [forwardEdge],
+          totalBeats: 0,
+        })),
+        getVisualizationData: vi.fn(() => ({ beats: [], edges: [] })),
+        deleteEdge: vi.fn(),
+        rebuildGraph: vi.fn(),
+        setUserAnchorEdge: vi.fn(),
+        getUserAnchorEdgeId: vi.fn(() => null),
+      } as unknown as AppContext["engine"],
+    });
+
+    const response: AnalysisComplete = {
+      status: "complete",
+      id: "job123",
+      result: { beats: [], track: {} },
+    };
+
+    applyAnalysisResult(context, response);
+
+    expect(context.engine.setUserAnchorEdge).not.toHaveBeenCalled();
   });
 
   it("adds nightcore suffix to displayed title in jukebox mode", () => {
@@ -986,6 +1087,128 @@ describe("playback controls", () => {
     expect(context.engine.seekToBeat).toHaveBeenCalledWith(0);
     expect(context.engine.play).not.toHaveBeenCalled();
     expect(context.engine.startJukebox).not.toHaveBeenCalled();
+  });
+});
+
+describe("playback branch shortcuts", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    setWindowUrl("http://localhost/listen/abc");
+  });
+
+  function makeHandlers(context: AppContext, showToast = vi.fn()) {
+    const writeTuningParamsToUrl = vi.fn();
+    return {
+      handlers: createPlaybackUiHandlers({
+        context,
+        elements: context.elements,
+        state: context.state,
+        player: context.player,
+        engine: context.engine,
+        jukebox: context.jukebox,
+        autocanonizer: context.autocanonizer,
+        vizStorageKey: "viz",
+        canonizerFinishKey: "finish",
+        setAnalysisStatus: vi.fn(),
+        showToast,
+        stopPlayback: vi.fn(),
+        togglePlayback: vi.fn(),
+        startJukeboxFromBeat: vi.fn(),
+        startAutocanonizerPlayback: vi.fn(),
+        updateTrackUrl: vi.fn(),
+        navigateToTab: vi.fn(),
+        updateVizVisibility: vi.fn(),
+        openExtras: vi.fn(),
+        syncTuningTabsUI: vi.fn(),
+        getTuningParamsFromEngine: vi.fn(() => {
+          const params = new URLSearchParams();
+          const anchorId = context.engine.getUserAnchorEdgeId();
+          if (anchorId !== null) {
+            params.set("ab", `${anchorId}`);
+          }
+          return params;
+        }),
+        writeTuningParamsToUrl,
+        syncDeletedEdgeState: vi.fn(),
+        updateTrackInfo: vi.fn(),
+        isEditableTarget: vi.fn(() => false),
+        getCurrentTrackId: vi.fn(() => null),
+      }),
+      showToast,
+      writeTuningParamsToUrl,
+    };
+  }
+
+  function keyEvent(key: string) {
+    return {
+      key,
+      repeat: false,
+      target: null,
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent;
+  }
+
+  it("sets and clears the selected backward branch as the user anchor", () => {
+    const context = createContext();
+    const edge = {
+      id: 7,
+      src: { which: 8 },
+      dest: { which: 2 },
+      deleted: false,
+    };
+    context.state.selectedEdge = edge as AppContext["state"]["selectedEdge"];
+    context.state.vizData = {
+      beats: [],
+      edges: [edge],
+      lastBranchPoint: 1,
+      anchorEdgeId: null,
+    } as unknown as AppContext["state"]["vizData"];
+    const nextVizData = {
+      beats: [],
+      edges: [edge],
+      lastBranchPoint: 1,
+      anchorEdgeId: 7,
+    };
+    (
+      context.engine.getVisualizationData as ReturnType<typeof vi.fn>
+    ).mockReturnValue(nextVizData);
+    const { handlers, showToast, writeTuningParamsToUrl } = makeHandlers(context);
+    const setEvent = keyEvent("A");
+
+    handlers.handleKeydown(setEvent);
+
+    expect(setEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(context.engine.setUserAnchorEdge).toHaveBeenCalledWith(edge);
+    expect(context.jukebox.setData).toHaveBeenCalledWith(nextVizData);
+    expect(context.jukebox.setSelectedEdgeActive).toHaveBeenCalledWith(edge);
+    expect(showToast).toHaveBeenCalledWith(context, "Anchor branch set");
+    expect(writeTuningParamsToUrl).toHaveBeenCalledWith("ab=7", true);
+
+    const resetEvent = keyEvent("a");
+    handlers.handleKeydown(resetEvent);
+
+    expect(resetEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(context.engine.setUserAnchorEdge).toHaveBeenLastCalledWith(null);
+    expect(showToast).toHaveBeenLastCalledWith(context, "Anchor branch reset");
+    expect(writeTuningParamsToUrl).toHaveBeenLastCalledWith(null, true);
+  });
+
+  it("ignores A for a selected forward branch", () => {
+    const context = createContext();
+    const edge = {
+      id: 8,
+      src: { which: 2 },
+      dest: { which: 5 },
+      deleted: false,
+    };
+    context.state.selectedEdge = edge as AppContext["state"]["selectedEdge"];
+    const { handlers } = makeHandlers(context);
+    const event = keyEvent("A");
+
+    handlers.handleKeydown(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(context.engine.setUserAnchorEdge).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/app/playback.ts
+++ b/web/src/app/playback.ts
@@ -1034,6 +1034,7 @@ export function resetForNewTrack(
     edges: [],
     lastBranchPoint: -1,
     anchorEdgeId: null,
+    userAnchorEdgeId: null,
   };
   jukebox.setData(emptyVizData);
   jukebox.reset();

--- a/web/src/app/playback.ts
+++ b/web/src/app/playback.ts
@@ -19,6 +19,7 @@ import { readCachedTrack, updateCachedTrack } from "./cache";
 import {
   applyTuningParamsFromUrl,
   clearTuningParamsFromUrl,
+  getAnchorBranchIdFromUrl,
   getDeletedEdgeIdsFromUrl,
   syncTuningParamsState,
   writeTuningParamsToUrl,
@@ -81,6 +82,19 @@ function applyDeletedEdgesFromUrl(context: AppContext) {
       context.jukebox.setData(context.state.vizData);
     }
   }
+}
+
+function applyAnchorBranchFromUrl(context: AppContext) {
+  const anchorBranchId = getAnchorBranchIdFromUrl();
+  if (anchorBranchId === null) {
+    return;
+  }
+  const graph = context.engine.getGraphState();
+  const edge = graph?.allEdges.find((candidate) => candidate.id === anchorBranchId);
+  if (!edge || edge.deleted || edge.dest.which >= edge.src.which) {
+    return;
+  }
+  context.engine.setUserAnchorEdge(edge);
 }
 
 export function syncDeletedEdgeState(context: AppContext) {
@@ -1065,6 +1079,7 @@ export function applyAnalysisResult(
   engine.loadAnalysis(response.result);
   cowbellOverlay.setSectionStartBeatIndices(engine.getSectionStartBeatIndices());
   applyDeletedEdgesFromUrl(context);
+  applyAnchorBranchFromUrl(context);
   autocanonizer.setAnalysis(response.result, response.result.track?.duration);
   const graph = engine.getGraphState();
   state.autoComputedThreshold =

--- a/web/src/app/tabs.test.ts
+++ b/web/src/app/tabs.test.ts
@@ -5,6 +5,7 @@ import {
   pathForFaqSubtab,
   pathForTab,
   updateTrackUrl,
+  urlForTrack,
 } from "./tabs";
 import { setWindowUrl } from "./__tests__/test-utils";
 
@@ -49,6 +50,24 @@ describe("tabs", () => {
     updateTrackUrl("xyz", true, "lg=1", "jukebox");
     expect(window.location.pathname).toBe("/listen/xyz");
     expect(window.location.search).toBe("?lg=1");
+  });
+
+  it("builds full track URLs with tuning params", () => {
+    const href = urlForTrack(
+      "soundcloud:track/with space",
+      "https://example.test/current?old=1",
+      "jb=1&d=2,8&am=nightcore",
+      "jukebox",
+    );
+    expect(href).toBe(
+      "https://example.test/listen/soundcloud%3Atrack%2Fwith%20space?jb=1&d=2,8&am=nightcore",
+    );
+  });
+
+  it("builds full track URLs without search when tuning is absent", () => {
+    expect(urlForTrack("abc123", "https://example.test/top", null, "jukebox")).toBe(
+      "https://example.test/listen/abc123",
+    );
   });
 
   it("updates track URL with audio mode tuning param", () => {

--- a/web/src/app/tabs.ts
+++ b/web/src/app/tabs.ts
@@ -20,6 +20,17 @@ export function pathForTab(tabId: TabId, youtubeId?: string | null) {
   return "/";
 }
 
+export function urlForTrack(
+  youtubeId: string,
+  baseUrl: string,
+  tuningParams?: string | null,
+  playMode?: "jukebox" | "autocanonizer",
+) {
+  const url = new URL(pathForTab("play", youtubeId), baseUrl);
+  url.search = buildSearchParams(tuningParams, playMode);
+  return url.toString();
+}
+
 export function pathForFaqSubtab(subtabId: FaqSubtabId) {
   return subtabId === "whats-new" ? "/whats-new" : "/faq";
 }
@@ -99,9 +110,9 @@ export function updateTrackUrl(
   tuningParams?: string | null,
   playMode?: "jukebox" | "autocanonizer"
 ) {
-  const url = new URL(window.location.href);
-  url.pathname = pathForTab("play", youtubeId);
-  url.search = buildSearchParams(tuningParams, playMode);
+  const url = new URL(
+    urlForTrack(youtubeId, window.location.href, tuningParams, playMode),
+  );
   if (replace) {
     window.history.replaceState({}, "", url.toString());
   } else {

--- a/web/src/app/tuning.test.ts
+++ b/web/src/app/tuning.test.ts
@@ -4,6 +4,7 @@ import type { JukeboxConfig } from "../engine/types";
 import {
   applyTuningParamsToEngine,
   clearTuningParamsFromUrl,
+  getAnchorBranchIdFromUrl,
   getDeletedEdgeIdsFromUrl,
   getTuningParamsFromEngine,
   syncTuningParamsState,
@@ -39,6 +40,7 @@ function createContext(
       config = { ...config, ...partial };
     },
     getGraphState: () => null,
+    getUserAnchorEdgeId: () => null,
   };
   return {
     defaultConfig,
@@ -149,9 +151,22 @@ describe("tuning params", () => {
     expect(params.get("d")).toBe("1,5");
   });
 
+  it("serializes user anchor branch id when present", () => {
+    const context = createContext();
+    (context.engine as { getUserAnchorEdgeId: () => number | null }).getUserAnchorEdgeId =
+      () => 7;
+    const params = getTuningParamsFromEngine(context);
+    expect(params.get("ab")).toBe("7");
+  });
+
   it("parses deleted edge ids from url", () => {
     setWindowUrl("http://localhost/listen/abc?d=3,5,notanumber,7");
     expect(getDeletedEdgeIdsFromUrl()).toEqual([3, 5, 7]);
+  });
+
+  it("parses anchor branch id from url", () => {
+    setWindowUrl("http://localhost/listen/abc?ab=12");
+    expect(getAnchorBranchIdFromUrl()).toBe(12);
   });
 
   it("syncs tuning params state from engine config", () => {

--- a/web/src/app/tuning.ts
+++ b/web/src/app/tuning.ts
@@ -2,7 +2,7 @@ import type { AppContext } from "./context";
 
 const MIN_RANDOM_BRANCH_DELTA = 0;
 const MAX_RANDOM_BRANCH_DELTA = 0.2;
-const TUNING_PARAM_KEYS = ["jb", "lg", "sq", "thresh", "bp", "d", "am"];
+const TUNING_PARAM_KEYS = ["jb", "lg", "sq", "thresh", "bp", "d", "am", "ab"];
 
 function parseAudioMode(raw: string | null) {
   if (
@@ -72,6 +72,12 @@ export function getDeletedEdgeIdsFromUrl(): number[] {
     .split(",")
     .map((value) => Number.parseInt(value, 10))
     .filter((value) => Number.isFinite(value) && value >= 0);
+}
+
+export function getAnchorBranchIdFromUrl(): number | null {
+  const params = new URLSearchParams(window.location.search);
+  const raw = Number.parseInt(params.get("ab") ?? "", 10);
+  return Number.isFinite(raw) && raw >= 0 ? raw : null;
 }
 
 export function getTuningParamsStringFromUrl(): string | null {
@@ -199,6 +205,10 @@ export function getTuningParamsFromEngine(context: AppContext): URLSearchParams 
     : context.state.deletedEdgeIds;
   if (deletedIds.length > 0) {
     params.set("d", deletedIds.join(","));
+  }
+  const anchorBranchId = context.engine.getUserAnchorEdgeId?.() ?? null;
+  if (anchorBranchId !== null) {
+    params.set("ab", `${anchorBranchId}`);
   }
   if (context.state.jukeboxAudioMode !== "off") {
     params.set("am", context.state.jukeboxAudioMode);

--- a/web/src/app/wire/favorites.ts
+++ b/web/src/app/wire/favorites.ts
@@ -3,6 +3,7 @@ import type { Elements } from "../elements";
 import { filterFavorites, type FavoriteTrack } from "../favorites";
 import type { AnalysisComplete } from "../api";
 import type { ToastOptions } from "../ui";
+import { urlForTrack } from "../tabs";
 
 type FavoritesDeps = {
   context: AppContext;
@@ -574,7 +575,12 @@ export function createFavoritesHandlers(deps: FavoritesDeps) {
         item.sourceType ??
         (item.uniqueSongId ? inferSourceTypeFromId(item.uniqueSongId) : "youtube");
       const link = document.createElement("a");
-      link.href = `/listen/${encodeURIComponent(item.uniqueSongId)}`;
+      link.href = urlForTrack(
+        item.uniqueSongId,
+        window.location.href,
+        item.tuningParams,
+        "jukebox",
+      );
       const titleText = item.title || "Untitled";
       const artist = (item.artist || "").trim();
       const showArtist = artist !== "" && artist !== "Unknown";

--- a/web/src/app/wire/playback.ts
+++ b/web/src/app/wire/playback.ts
@@ -9,6 +9,7 @@ import type { ToastOptions } from "../ui";
 import { VISUALIZATION_LABELS } from "../constants";
 import { formatDuration, formatPlaybackTitle } from "../format";
 import { setAutoMarqueeText } from "../marquee";
+import { serializeParams } from "../tuning";
 
 type PlaybackUiDeps = {
   context: AppContext;
@@ -319,6 +320,30 @@ export function createPlaybackUiHandlers(deps: PlaybackUiDeps) {
     syncExtrasPopup(nextEdge);
   }
 
+  function toggleSelectedAnchorBranch() {
+    const edge = state.selectedEdge;
+    if (!edge || edge.deleted || edge.dest.which >= edge.src.which) {
+      return false;
+    }
+    const nextAnchor = engine.getUserAnchorEdgeId() === edge.id ? null : edge;
+    engine.setUserAnchorEdge(nextAnchor);
+    state.vizData = engine.getVisualizationData();
+    const data = state.vizData;
+    if (data) {
+      jukebox.setData(data);
+    }
+    jukebox.setSelectedEdgeActive(edge);
+    const tuningParams = getTuningParamsFromEngine(context);
+    const result = serializeParams(tuningParams);
+    state.tuningParams = result.length > 0 ? result : null;
+    writeTuningParamsToUrl(state.tuningParams, true);
+    showToast(
+      context,
+      nextAnchor ? "Anchor branch set" : "Anchor branch reset",
+    );
+    return true;
+  }
+
   function handleKeydown(event: KeyboardEvent) {
     if (state.activeTabId !== "play") {
       return;
@@ -351,6 +376,12 @@ export function createPlaybackUiHandlers(deps: PlaybackUiDeps) {
         context,
         `Bring It Home ${enabled ? "enabled" : "disabled"}`,
       );
+      return;
+    }
+    if ((event.key === "a" || event.key === "A") && !event.repeat) {
+      if (toggleSelectedAnchorBranch()) {
+        event.preventDefault();
+      }
       return;
     }
     if (

--- a/web/src/cast/main.test.ts
+++ b/web/src/cast/main.test.ts
@@ -50,6 +50,8 @@ const doubles = vi.hoisted(() => {
       clearDeletedEdges: vi.fn(),
       rebuildGraph: vi.fn(),
       deleteEdge: vi.fn(),
+      setUserAnchorEdge: vi.fn(),
+      getUserAnchorEdgeId: vi.fn(() => null),
       getGraphState: vi.fn(() => ({
         computedThreshold: 18,
         currentThreshold: 20,

--- a/web/src/cast/main.ts
+++ b/web/src/cast/main.ts
@@ -60,6 +60,7 @@ type CastTuningStatus = {
     deltaPercent: number;
   };
   deletedEdgeIds: number[];
+  anchorBranchId: number | null;
   highlightAnchorBranch: boolean;
   audioMode: JukeboxAudioMode;
 };
@@ -463,6 +464,7 @@ async function bootstrap() {
         ),
       },
       deletedEdgeIds,
+      anchorBranchId: engine.getUserAnchorEdgeId(),
       highlightAnchorBranch: anchorHighlightEnabled,
       audioMode: state.audioMode,
     };

--- a/web/src/cast/tuning.test.ts
+++ b/web/src/cast/tuning.test.ts
@@ -28,9 +28,18 @@ function makeEngine(): CastTuningEngine {
     dest: { which: 1 },
     deleted: false,
   } as any;
+  const edgeB = {
+    id: 2,
+    src: { which: 1 },
+    dest: { which: 5 },
+    deleted: false,
+  } as any;
   return {
     updateConfig: vi.fn(),
-    clearDeletedEdges: vi.fn(),
+    clearDeletedEdges: vi.fn(() => {
+      edgeA.deleted = false;
+      edgeB.deleted = false;
+    }),
     rebuildGraph: vi.fn(),
     getGraphState: vi.fn(() => ({
       computedThreshold: 20,
@@ -38,16 +47,19 @@ function makeEngine(): CastTuningEngine {
       lastBranchPoint: 4,
       totalBeats: 10,
       longestReach: 0,
-      allEdges: [edgeA],
+      allEdges: [edgeA, edgeB],
     })),
-    deleteEdge: vi.fn(),
+    deleteEdge: vi.fn((edge: { deleted: boolean }) => {
+      edge.deleted = true;
+    }),
+    setUserAnchorEdge: vi.fn(),
   };
 }
 
 describe("cast tuning", () => {
   it("parses supported fields including booleans, highlight, and audio mode", () => {
     const parsed = parseCastTuningParams(
-      "jb=1&lg=0&sq=0&thresh=31&bp=10,20,30&d=1,3&ah=1&am=eight_d",
+      "jb=1&lg=0&sq=0&thresh=31&bp=10,20,30&d=1,3&ah=1&am=eight_d&ab=7",
       makeDefaults(),
     );
     expect(parsed).not.toBeNull();
@@ -57,6 +69,7 @@ describe("cast tuning", () => {
     expect(parsed?.config.currentThreshold).toBe(31);
     expect(parsed?.config.randomBranchChanceDelta).toBeCloseTo(0.06, 6);
     expect(parsed?.deletedEdgeIds).toEqual([1, 3]);
+    expect(parsed?.anchorBranchId).toBe(7);
     expect(parsed?.highlightAnchorBranch).toBe(true);
     expect(parsed?.audioMode).toBe("eight_d");
     expect(parsed?.hasAudioModeParam).toBe(true);
@@ -102,6 +115,12 @@ describe("cast tuning", () => {
   it("filters invalid deleted edge ids", () => {
     const parsed = parseCastTuningParams("d=4,-1,foo,6", makeDefaults());
     expect(parsed?.deletedEdgeIds).toEqual([4, 6]);
+  });
+
+  it("parses valid anchor branch ids", () => {
+    const parsed = parseCastTuningParams("ab=4", makeDefaults());
+    expect(parsed?.anchorBranchId).toBe(4);
+    expect(parsed?.hasGraphTuning).toBe(true);
   });
 
   it("returns null when no tuning keys are present", () => {
@@ -187,6 +206,26 @@ describe("cast tuning", () => {
     expect(engine.clearDeletedEdges).toHaveBeenCalledTimes(1);
     expect(engine.rebuildGraph).toHaveBeenCalledTimes(2);
     expect(engine.deleteEdge).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies backward anchor branch ids after graph tuning", () => {
+    const engine = makeEngine();
+    const result = applyCastTuningToEngine(engine, makeDefaults(), "ab=1");
+    expect(result.parsed?.anchorBranchId).toBe(1);
+    expect(engine.setUserAnchorEdge).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1 }),
+    );
+  });
+
+  it("ignores forward or deleted anchor branch ids", () => {
+    const forwardEngine = makeEngine();
+    applyCastTuningToEngine(forwardEngine, makeDefaults(), "ab=2");
+    expect(forwardEngine.setUserAnchorEdge).not.toHaveBeenCalled();
+
+    const deletedEngine = makeEngine();
+    applyCastTuningToEngine(deletedEngine, makeDefaults(), "d=1&ab=1");
+    expect(deletedEngine.deleteEdge).toHaveBeenCalledTimes(1);
+    expect(deletedEngine.setUserAnchorEdge).not.toHaveBeenCalled();
   });
 
   it("resets to defaults when no cast tuning params are provided", () => {

--- a/web/src/cast/tuning.ts
+++ b/web/src/cast/tuning.ts
@@ -4,7 +4,17 @@ import type { JukeboxAudioMode } from "../audio/BufferedAudioPlayer";
 
 const MIN_RANDOM_BRANCH_DELTA = 0;
 const MAX_RANDOM_BRANCH_DELTA = 0.2;
-const TUNING_PARAM_KEYS = ["jb", "lg", "sq", "thresh", "bp", "d", "ah", "am"];
+const TUNING_PARAM_KEYS = [
+  "jb",
+  "lg",
+  "sq",
+  "thresh",
+  "bp",
+  "d",
+  "ah",
+  "am",
+  "ab",
+];
 
 function clamp(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value));
@@ -25,6 +35,11 @@ function parseDeletedEdgeIds(raw: string | null): number[] {
     .filter((value) => Number.isFinite(value) && value >= 0);
 }
 
+function parseAnchorBranchId(raw: string | null): number | null {
+  const value = Number.parseInt(raw ?? "", 10);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
 function parseAudioMode(raw: string | null): JukeboxAudioMode | null {
   if (
     raw === "off" ||
@@ -42,6 +57,7 @@ function parseAudioMode(raw: string | null): JukeboxAudioMode | null {
 export type CastParsedTuning = {
   config: JukeboxConfig;
   deletedEdgeIds: number[];
+  anchorBranchId: number | null;
   highlightAnchorBranch: boolean;
   audioMode: JukeboxAudioMode | null;
   hasAudioModeParam: boolean;
@@ -73,7 +89,7 @@ export function parseCastTuningParams(
     }
     return null;
   };
-  const hasGraphTuning = ["jb", "lg", "sq", "thresh", "bp", "d"].some((key) =>
+  const hasGraphTuning = ["jb", "lg", "sq", "thresh", "bp", "d", "ab"].some((key) =>
     params.has(key),
   );
   const nextConfig: JukeboxConfig = { ...defaults };
@@ -121,12 +137,14 @@ export function parseCastTuningParams(
     }
   }
   const deletedEdgeIds = parseDeletedEdgeIds(params.get("d"));
+  const anchorBranchId = parseAnchorBranchId(params.get("ab"));
   const highlightAnchorBranch = parseBool(params.get("ah")) ?? false;
   const hasAudioModeParam = params.has("am");
   const audioMode = parseAudioMode(params.get("am"));
   return {
     config: nextConfig,
     deletedEdgeIds,
+    anchorBranchId,
     highlightAnchorBranch,
     audioMode,
     hasAudioModeParam,
@@ -142,7 +160,12 @@ export type CastTuningApplyResult = {
 
 export type CastTuningEngine = Pick<
   JukeboxEngine,
-  "updateConfig" | "clearDeletedEdges" | "rebuildGraph" | "getGraphState" | "deleteEdge"
+  | "updateConfig"
+  | "clearDeletedEdges"
+  | "rebuildGraph"
+  | "getGraphState"
+  | "deleteEdge"
+  | "setUserAnchorEdge"
 >;
 
 export function applyCastTuningToEngine(
@@ -169,6 +192,15 @@ export function applyCastTuningToEngine(
         }
       }
       engine.rebuildGraph();
+    }
+  }
+  if (parsed?.anchorBranchId !== null && parsed?.anchorBranchId !== undefined) {
+    const graph = engine.getGraphState();
+    const edge = graph?.allEdges.find(
+      (candidate) => candidate.id === parsed.anchorBranchId,
+    );
+    if (edge && !edge.deleted && edge.dest.which < edge.src.which) {
+      engine.setUserAnchorEdge(edge);
     }
   }
   return { parsed, highlightOnly: false, highlightAnchorBranch };

--- a/web/src/engine/JukeboxEngine.test.ts
+++ b/web/src/engine/JukeboxEngine.test.ts
@@ -705,6 +705,7 @@ describe("JukeboxEngine graph maintenance", () => {
 
     expect(engine.getUserAnchorEdgeId()).toBe(userEdge.id);
     expect(engine.getVisualizationData()?.anchorEdgeId).toBe(userEdge.id);
+    expect(engine.getVisualizationData()?.userAnchorEdgeId).toBe(userEdge.id);
 
     engineAny.currentBeatIndex = 0;
     engineAny.nextAudioTime = 1;
@@ -723,6 +724,7 @@ describe("JukeboxEngine graph maintenance", () => {
     engine.setUserAnchorEdge(null);
     expect(engine.getUserAnchorEdgeId()).toBeNull();
     expect(engine.getVisualizationData()?.anchorEdgeId).toBe(defaultEdge.id);
+    expect(engine.getVisualizationData()?.userAnchorEdgeId).toBeNull();
   });
 
   it("falls back to the default anchor when the user anchor is deleted", () => {
@@ -770,6 +772,7 @@ describe("JukeboxEngine graph maintenance", () => {
 
     expect(engine.getUserAnchorEdgeId()).toBeNull();
     expect(engine.getVisualizationData()?.anchorEdgeId).toBe(defaultEdge.id);
+    expect(engine.getVisualizationData()?.userAnchorEdgeId).toBeNull();
   });
 
   it("does not take forward branches that skip past a user-selected anchor", () => {

--- a/web/src/engine/JukeboxEngine.test.ts
+++ b/web/src/engine/JukeboxEngine.test.ts
@@ -646,6 +646,198 @@ describe("JukeboxEngine graph maintenance", () => {
       expect(targetTime).not.toBe(edge.dest.start);
     }
   });
+
+  it("uses a user-selected anchor edge for visualization and forced anchor jumps", () => {
+    const player = makePlayer();
+    const engine = new JukeboxEngine(player, {
+      randomMode: "seeded",
+      seed: 1,
+      config: {
+        minRandomBranchChance: 0,
+        maxRandomBranchChance: 0,
+        randomBranchChanceDelta: 0,
+      },
+    });
+    const beats = [0, 1, 2, 3].map(makeBeat);
+    linkBeats(beats);
+    const defaultEdge: Edge = {
+      id: 1,
+      src: beats[1],
+      dest: beats[0],
+      distance: 10,
+      deleted: false,
+    };
+    const userEdge: Edge = {
+      id: 3,
+      src: beats[3],
+      dest: beats[0],
+      distance: 5,
+      deleted: false,
+    };
+    beats[1].neighbors = [defaultEdge];
+    beats[1].allNeighbors = [defaultEdge];
+    beats[3].neighbors = [userEdge];
+    beats[3].allNeighbors = [userEdge];
+    const graph: JukeboxGraphState = {
+      computedThreshold: 0,
+      currentThreshold: 0,
+      lastBranchPoint: 1,
+      totalBeats: beats.length,
+      longestReach: 0,
+      allEdges: [defaultEdge, userEdge],
+    };
+    const engineAny = engine as unknown as {
+      analysis: TrackAnalysis;
+      graph: JukeboxGraphState;
+      beats: QuantumBase[];
+      currentBeatIndex: number;
+      nextAudioTime: number;
+      curRandomBranchChance: number;
+      advanceBeat: (audioTime: number) => void;
+    };
+    engineAny.analysis = makeAnalysis(beats);
+    engineAny.graph = graph;
+    engineAny.beats = beats;
+    engineAny.curRandomBranchChance = engine.getConfig().minRandomBranchChance;
+
+    expect(engine.getVisualizationData()?.anchorEdgeId).toBe(defaultEdge.id);
+    engine.setUserAnchorEdge(userEdge);
+
+    expect(engine.getUserAnchorEdgeId()).toBe(userEdge.id);
+    expect(engine.getVisualizationData()?.anchorEdgeId).toBe(userEdge.id);
+
+    engineAny.currentBeatIndex = 0;
+    engineAny.nextAudioTime = 1;
+    engineAny.advanceBeat(engineAny.nextAudioTime);
+
+    expect(engineAny.currentBeatIndex).toBe(1);
+    expect(player.scheduleJump).not.toHaveBeenCalled();
+
+    engineAny.currentBeatIndex = 2;
+    engineAny.nextAudioTime = 3;
+    engineAny.advanceBeat(engineAny.nextAudioTime);
+
+    expect(engineAny.currentBeatIndex).toBe(0);
+    expect(player.scheduleJump).toHaveBeenCalledWith(0, 3);
+
+    engine.setUserAnchorEdge(null);
+    expect(engine.getUserAnchorEdgeId()).toBeNull();
+    expect(engine.getVisualizationData()?.anchorEdgeId).toBe(defaultEdge.id);
+  });
+
+  it("falls back to the default anchor when the user anchor is deleted", () => {
+    const player = makePlayer();
+    const engine = new JukeboxEngine(player);
+    const beats = [0, 1, 2, 3].map(makeBeat);
+    linkBeats(beats);
+    const defaultEdge: Edge = {
+      id: 1,
+      src: beats[3],
+      dest: beats[0],
+      distance: 10,
+      deleted: false,
+    };
+    const userEdge: Edge = {
+      id: 2,
+      src: beats[2],
+      dest: beats[0],
+      distance: 5,
+      deleted: false,
+    };
+    beats[3].neighbors = [defaultEdge];
+    beats[3].allNeighbors = [defaultEdge];
+    beats[2].neighbors = [userEdge];
+    beats[2].allNeighbors = [userEdge];
+    const graph: JukeboxGraphState = {
+      computedThreshold: 0,
+      currentThreshold: 0,
+      lastBranchPoint: 3,
+      totalBeats: beats.length,
+      longestReach: 0,
+      allEdges: [defaultEdge, userEdge],
+    };
+    const engineAny = engine as unknown as {
+      analysis: TrackAnalysis;
+      graph: JukeboxGraphState;
+      beats: QuantumBase[];
+    };
+    engineAny.analysis = makeAnalysis(beats);
+    engineAny.graph = graph;
+    engineAny.beats = beats;
+
+    engine.setUserAnchorEdge(userEdge);
+    engine.deleteEdge(userEdge);
+
+    expect(engine.getUserAnchorEdgeId()).toBeNull();
+    expect(engine.getVisualizationData()?.anchorEdgeId).toBe(defaultEdge.id);
+  });
+
+  it("does not take forward branches that skip past a user-selected anchor", () => {
+    const player = makePlayer();
+    const engine = new JukeboxEngine(player, {
+      config: {
+        minRandomBranchChance: 1,
+        maxRandomBranchChance: 1,
+        randomBranchChanceDelta: 0,
+      },
+    });
+    const beats = [0, 1, 2, 3, 4, 5].map(makeBeat);
+    linkBeats(beats);
+    const safeEdge: Edge = {
+      id: 1,
+      src: beats[1],
+      dest: beats[0],
+      distance: 100,
+      deleted: false,
+    };
+    const skipPastAnchorEdge: Edge = {
+      id: 2,
+      src: beats[1],
+      dest: beats[5],
+      distance: 1,
+      deleted: false,
+    };
+    const userAnchorEdge: Edge = {
+      id: 3,
+      src: beats[4],
+      dest: beats[0],
+      distance: 1,
+      deleted: false,
+    };
+    beats[1].neighbors = [skipPastAnchorEdge, safeEdge];
+    beats[1].allNeighbors = [skipPastAnchorEdge, safeEdge];
+    beats[4].neighbors = [userAnchorEdge];
+    beats[4].allNeighbors = [userAnchorEdge];
+    const graph: JukeboxGraphState = {
+      computedThreshold: 0,
+      currentThreshold: 0,
+      lastBranchPoint: 4,
+      totalBeats: beats.length,
+      longestReach: 0,
+      allEdges: [safeEdge, skipPastAnchorEdge, userAnchorEdge],
+    };
+    const engineAny = engine as unknown as {
+      analysis: TrackAnalysis;
+      graph: JukeboxGraphState;
+      beats: QuantumBase[];
+      currentBeatIndex: number;
+      nextAudioTime: number;
+      curRandomBranchChance: number;
+      advanceBeat: (audioTime: number) => void;
+    };
+    engineAny.analysis = makeAnalysis(beats);
+    engineAny.graph = graph;
+    engineAny.beats = beats;
+    engineAny.currentBeatIndex = 0;
+    engineAny.nextAudioTime = 1;
+    engineAny.curRandomBranchChance = engine.getConfig().minRandomBranchChance;
+    engine.setUserAnchorEdge(userAnchorEdge);
+
+    engineAny.advanceBeat(engineAny.nextAudioTime);
+
+    expect(engineAny.currentBeatIndex).toBe(0);
+    expect(player.scheduleJump).toHaveBeenCalledWith(0, 1);
+  });
 });
 
 describe("JukeboxEngine jump timing", () => {

--- a/web/src/engine/JukeboxEngine.ts
+++ b/web/src/engine/JukeboxEngine.ts
@@ -184,12 +184,19 @@ export class JukeboxEngine {
         }
       }
     }
-    const anchorEdgeId = this.getActiveAnchorEdge()?.id ?? null;
+    const userAnchorEdge = this.getUserAnchorEdge();
+    const defaultAnchorEdge = this.getDefaultAnchorEdge();
+    const anchorEdgeId = userAnchorEdge?.id ?? defaultAnchorEdge?.id ?? null;
+    const userAnchorEdgeId =
+      userAnchorEdge && userAnchorEdge.id !== defaultAnchorEdge?.id
+        ? userAnchorEdge.id
+        : null;
     return {
       beats: this.beats,
       edges: Array.from(edgeMap.values()),
       lastBranchPoint: this.graph.lastBranchPoint,
       anchorEdgeId,
+      userAnchorEdgeId,
     };
   }
 
@@ -350,10 +357,6 @@ export class JukeboxEngine {
     const bestIndex = getBestLastBranchNeighborIndex(anchorSource);
     const bestEdge = anchorSource.neighbors[bestIndex];
     return bestEdge && !bestEdge.deleted ? bestEdge : null;
-  }
-
-  private getActiveAnchorEdge(): Edge | null {
-    return this.getUserAnchorEdge() ?? this.getDefaultAnchorEdge();
   }
 
   private ensureAnchorSourceHasNeighbors() {

--- a/web/src/engine/JukeboxEngine.ts
+++ b/web/src/engine/JukeboxEngine.ts
@@ -9,8 +9,10 @@ import {
   BranchState,
   getBestLastBranchNeighborIndex,
   selectNextBeatIndex,
+  UserAnchorSelection,
 } from "./selection";
 import {
+  Edge,
   JukeboxConfig,
   JukeboxGraphState,
   JukeboxState,
@@ -83,6 +85,7 @@ export class JukeboxEngine {
   private bringItHomeMode = false;
   private pendingAdvance: PendingAdvance | null = null;
   private deletedEdgeKeys = new Set<string>();
+  private userAnchorEdgeId: number | null = null;
   private rng: () => number;
   private listener: UpdateListener | null = null;
   private branchState: BranchState = {
@@ -122,6 +125,7 @@ export class JukeboxEngine {
 
   loadAnalysis(data: unknown) {
     this.deletedEdgeKeys.clear();
+    this.userAnchorEdgeId = null;
     this.analysis = normalizeAnalysis(data);
     this.config.minLongBranch = Math.floor(this.analysis.beats.length / 5);
     this.graph = buildJumpGraph(this.analysis, this.config);
@@ -140,6 +144,15 @@ export class JukeboxEngine {
 
   updateConfig(partial: Partial<JukeboxConfig>) {
     this.config = { ...this.config, ...partial };
+  }
+
+  setUserAnchorEdge(edge: Edge | null) {
+    this.userAnchorEdgeId = edge ? edge.id : null;
+    this.clearPendingAdvance(true);
+  }
+
+  getUserAnchorEdgeId(): number | null {
+    return this.getUserAnchorEdge()?.id ?? null;
   }
 
   rebuildGraph() {
@@ -171,15 +184,7 @@ export class JukeboxEngine {
         }
       }
     }
-    let anchorEdgeId: number | null = null;
-    const anchorSource = this.beats[this.graph.lastBranchPoint];
-    if (anchorSource && anchorSource.neighbors.length > 0) {
-      const bestIndex = getBestLastBranchNeighborIndex(anchorSource);
-      const bestEdge = anchorSource.neighbors[bestIndex];
-      if (bestEdge && !bestEdge.deleted) {
-        anchorEdgeId = bestEdge.id;
-      }
-    }
+    const anchorEdgeId = this.getActiveAnchorEdge()?.id ?? null;
     return {
       beats: this.beats,
       edges: Array.from(edgeMap.values()),
@@ -264,6 +269,7 @@ export class JukeboxEngine {
 
   clearDeletedEdges() {
     this.deletedEdgeKeys.clear();
+    this.userAnchorEdgeId = null;
     this.clearPendingAdvance(true);
     this.clearEdgeDeletionFlags();
   }
@@ -311,6 +317,43 @@ export class JukeboxEngine {
       beat.neighbors = beat.neighbors.filter((edge) => !edge.deleted);
     }
     this.ensureAnchorSourceHasNeighbors();
+  }
+
+  private getActiveUserAnchorSelection(): UserAnchorSelection | null {
+    const edge = this.getUserAnchorEdge();
+    return edge ? { edgeId: edge.id, sourceIndex: edge.src.which } : null;
+  }
+
+  private getUserAnchorEdge(): Edge | null {
+    if (!this.graph || this.userAnchorEdgeId === null) {
+      return null;
+    }
+    const edge = this.graph.allEdges.find(
+      (candidate) => candidate.id === this.userAnchorEdgeId,
+    );
+    if (!edge || edge.deleted) {
+      return null;
+    }
+    return edge.src.neighbors.some((candidate) => candidate.id === edge.id)
+      ? edge
+      : null;
+  }
+
+  private getDefaultAnchorEdge(): Edge | null {
+    if (!this.graph) {
+      return null;
+    }
+    const anchorSource = this.beats[this.graph.lastBranchPoint];
+    if (!anchorSource || anchorSource.neighbors.length === 0) {
+      return null;
+    }
+    const bestIndex = getBestLastBranchNeighborIndex(anchorSource);
+    const bestEdge = anchorSource.neighbors[bestIndex];
+    return bestEdge && !bestEdge.deleted ? bestEdge : null;
+  }
+
+  private getActiveAnchorEdge(): Edge | null {
+    return this.getUserAnchorEdge() ?? this.getDefaultAnchorEdge();
   }
 
   private ensureAnchorSourceHasNeighbors() {
@@ -512,6 +555,7 @@ export class JukeboxEngine {
           this.rng,
           this.branchState,
           this.forceBranch,
+          this.getActiveUserAnchorSelection(),
         );
         this.curRandomBranchChance = this.branchState.curRandomBranchChance;
         shouldJump = selection.jumped;

--- a/web/src/engine/selection.ts
+++ b/web/src/engine/selection.ts
@@ -5,6 +5,11 @@ export interface BranchState {
   lastDestBySource?: Map<number, number> | null;
 }
 
+export interface UserAnchorSelection {
+  edgeId: number;
+  sourceIndex: number;
+}
+
 const REFERENCE_BEAT_DURATION_SECONDS = 0.5;
 
 function collectTimeline(seed: QuantumBase): QuantumBase[] {
@@ -194,9 +199,10 @@ export function shouldRandomBranch(
   graph: JukeboxGraphState,
   config: JukeboxConfig,
   rng: () => number,
-  state: BranchState
+  state: BranchState,
+  suppressDefaultAnchor = false
 ): boolean {
-  if (q.which === graph.lastBranchPoint) {
+  if (!suppressDefaultAnchor && q.which === graph.lastBranchPoint) {
     return true;
   }
   // Gradually increase branch chance by elapsed musical time (not raw beat
@@ -225,21 +231,62 @@ export function selectNextBeatIndex(
   config: JukeboxConfig,
   rng: () => number,
   state: BranchState,
-  forceBranch = false
+  forceBranch = false,
+  userAnchor: UserAnchorSelection | null = null
 ): { index: number; jumped: boolean } {
   if (seed.neighbors.length === 0) {
     return { index: seed.which, jumped: false };
   }
-  if (!forceBranch && !shouldRandomBranch(seed, graph, config, rng, state)) {
+  const userAnchorIndex =
+    userAnchor === null
+      ? -1
+      : seed.neighbors.findIndex((edge) => edge.id === userAnchor.edgeId);
+  const candidateIndexes =
+    userAnchor !== null && seed.which < userAnchor.sourceIndex
+      ? seed.neighbors
+          .map((edge, index) =>
+            edge.dest.which < userAnchor.sourceIndex ? index : -1,
+          )
+          .filter((index) => index >= 0)
+      : undefined;
+  if (
+    userAnchorIndex < 0 &&
+    candidateIndexes?.length === 0
+  ) {
+    return { index: seed.which, jumped: false };
+  }
+  if (
+    userAnchorIndex < 0 &&
+    !forceBranch &&
+    !shouldRandomBranch(
+      seed,
+      graph,
+      config,
+      rng,
+      state,
+      userAnchor !== null,
+    )
+  ) {
     return { index: seed.which, jumped: false };
   }
   let nextEdge;
-  if (seed.which === graph.lastBranchPoint) {
+  if (userAnchorIndex >= 0) {
+    const selected = seed.neighbors.splice(userAnchorIndex, 1);
+    nextEdge = selected[0];
+  } else if (userAnchor === null && seed.which === graph.lastBranchPoint) {
     const bestIndex = getBestLastBranchNeighborIndex(seed);
     const selected = seed.neighbors.splice(bestIndex, 1);
     nextEdge = selected[0];
   } else {
-    const selectedIndex = selectWeightedNeighborIndex(seed, rng, state);
+    const selectedIndex = selectWeightedNeighborIndex(
+      seed,
+      rng,
+      state,
+      candidateIndexes,
+    );
+    if (selectedIndex < 0) {
+      return { index: seed.which, jumped: false };
+    }
     const selected = seed.neighbors.splice(selectedIndex, 1);
     nextEdge = selected[0];
   }
@@ -259,12 +306,16 @@ function selectWeightedNeighborIndex(
   seed: QuantumBase,
   rng: () => number,
   state: BranchState,
+  candidateIndexes?: number[],
 ): number {
-  if (seed.neighbors.length <= 1) {
-    return 0;
+  const indexes =
+    candidateIndexes ?? seed.neighbors.map((_edge, index) => index);
+  if (indexes.length <= 1) {
+    return indexes[0] ?? -1;
   }
   const lastDest = state.lastDestBySource?.get(seed.which);
-  const weights = seed.neighbors.map((edge) => {
+  const weights = indexes.map((index) => {
+    const edge = seed.neighbors[index];
     const distanceWeight = 1 / (1 + Math.max(0, edge.distance));
     const repeatPenalty =
       lastDest !== undefined && edge.dest.which === lastDest ? 0.35 : 1;
@@ -279,8 +330,8 @@ function selectWeightedNeighborIndex(
   for (let i = 0; i < weights.length; i += 1) {
     target -= weights[i];
     if (target <= 0) {
-      return i;
+      return indexes[i];
     }
   }
-  return weights.length - 1;
+  return indexes[indexes.length - 1] ?? -1;
 }

--- a/web/src/jukebox/JukeboxViz.test.ts
+++ b/web/src/jukebox/JukeboxViz.test.ts
@@ -192,6 +192,40 @@ describe("JukeboxViz", () => {
     expect(onEdgeSelect).toHaveBeenCalledWith(null);
   });
 
+  it("draws user-selected anchor highlight even when anchor highlighting is disabled", () => {
+    const container = createContainer();
+    const viz = new JukeboxViz(container);
+    const edge = {
+      id: 7,
+      src: { which: 0 },
+      dest: { which: 1 },
+      deleted: false,
+    };
+    viz.setData(
+      {
+        beats: [
+          { which: 0, start: 0, duration: 1 },
+          { which: 1, start: 1, duration: 1 },
+        ],
+        edges: [edge],
+        lastBranchPoint: 0,
+        anchorEdgeId: 7,
+        userAnchorEdgeId: 7,
+      } as any
+    );
+    const active = (viz as any).activeViz;
+    const drawEdge = vi.spyOn(active, "drawEdge");
+
+    active.drawBase();
+
+    expect(drawEdge).toHaveBeenCalledWith(
+      expect.anything(),
+      edge,
+      "#ff2d2d",
+      1.8,
+    );
+  });
+
   it("swaps visualization instances when active index changes", () => {
     const container = createContainer();
     const viz = new JukeboxViz(container);

--- a/web/src/jukebox/JukeboxViz.ts
+++ b/web/src/jukebox/JukeboxViz.ts
@@ -21,6 +21,7 @@ interface VisualizationData {
   edges: Edge[];
   lastBranchPoint: number;
   anchorEdgeId: number | null;
+  userAnchorEdgeId: number | null;
 }
 
 const ANCHOR_HIGHLIGHT_COLOR = "#ff2d2d";
@@ -362,9 +363,12 @@ class CanvasViz {
       }
     }
 
-    if (this.anchorHighlightEnabled && this.data.anchorEdgeId !== null) {
+    const highlightedAnchorEdgeId =
+      this.data.userAnchorEdgeId ??
+      (this.anchorHighlightEnabled ? this.data.anchorEdgeId : null);
+    if (highlightedAnchorEdgeId !== null) {
       for (const edge of edges) {
-        if (edge.deleted || edge.id !== this.data.anchorEdgeId) {
+        if (edge.deleted || edge.id !== highlightedAnchorEdgeId) {
           continue;
         }
         this.drawEdge(this.baseCtx, edge, ANCHOR_HIGHLIGHT_COLOR, 1.8);


### PR DESCRIPTION
Adds user-selected anchor branches for Jukebox playback.

Users can now select a backward branch and press `A` to make it the forced anchor jump. Pressing `A` again on that same selected anchor clears the override and restores the default anchor behavior.

- Adds session-local user anchor support to both web and PWA Jukebox engines.
- Updates branch selection so the user-selected anchor replaces the default forced anchor while active.
- Prevents earlier forward branches from jumping past the user-selected anchor source, matching the default anchor boundary behavior.
- Adds keyboard handling for `A` in hosted web and PWA Listen UI.
- Adds web URL support via `ab=<edge id>`.
- Updates shortcut help and What’s New copy.