### PR TITLE
error message cleanup

### DIFF
--- a/web/src/app/errorDisplay.test.ts
+++ b/web/src/app/errorDisplay.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  cleanErrorMessage,
+  formatErrorForDisplay,
+  inferSourceProviderFromUrl,
+} from "./errorDisplay";
+
+describe("errorDisplay", () => {
+  it("strips repeated Error prefixes", () => {
+    expect(cleanErrorMessage("Error: ERROR: Unable to download video data."))
+      .toBe("Unable to download video data.");
+  });
+
+  it("strips API ERROR prefixes", () => {
+    expect(cleanErrorMessage("ERROR: No beats or downbeats were detected in this audio."))
+      .toBe("No beats or downbeats were detected in this audio.");
+  });
+
+  it("preserves meaningful track errors", () => {
+    expect(formatErrorForDisplay(
+      "ERROR: No beats or downbeats were detected in this audio.",
+      { errorCode: "no_beats_detected", sourceProvider: "youtube" },
+    )).toBe("No beats or downbeats were detected in this audio.");
+    expect(formatErrorForDisplay(
+      "Error: Sorry, the max track length for this server is 12 minutes.",
+      { errorCode: "track_too_long", sourceProvider: "youtube" },
+    )).toBe("Sorry, the max track length for this server is 12 minutes.");
+  });
+
+  it("uses source-specific copy for fetch failures", () => {
+    expect(formatErrorForDisplay(
+      "ERROR: Unable to download video data.",
+      { errorCode: "download_unavailable", sourceProvider: "soundcloud" },
+    )).toBe("SoundCloud fetch failed.");
+    expect(formatErrorForDisplay(
+      Object.assign(new Error("Error: ERROR: Unable to reach YouTube"), {
+        code: "youtube_unreachable",
+      }),
+      { sourceProvider: "youtube" },
+    )).toBe("YouTube fetch failed.");
+  });
+
+  it("falls back for unknown errors", () => {
+    expect(formatErrorForDisplay(null, { fallback: "Load failed." }))
+      .toBe("Load failed.");
+  });
+
+  it("infers supported providers from URLs", () => {
+    expect(inferSourceProviderFromUrl("https://soundcloud.com/artist/track"))
+      .toBe("soundcloud");
+    expect(inferSourceProviderFromUrl("https://artist.bandcamp.com/track/song"))
+      .toBe("bandcamp");
+    expect(inferSourceProviderFromUrl("dQw4w9WgXcQ")).toBe("youtube");
+  });
+});

--- a/web/src/app/errorDisplay.ts
+++ b/web/src/app/errorDisplay.ts
@@ -1,0 +1,116 @@
+type ErrorLike = Error & {
+  code?: string;
+};
+
+export type ErrorDisplayOptions = {
+  sourceProvider?: string | null;
+  errorCode?: string | null;
+  fallback?: string;
+};
+
+const GENERIC_ERROR_MESSAGE =
+  "Something went wrong. Please try again or report an issue on GitHub.";
+
+const FETCH_FAILURE_CODES = new Set([
+  "download_unavailable",
+  "youtube_unavailable",
+  "youtube_unreachable",
+]);
+
+const FETCH_FAILURE_MESSAGES = new Set([
+  "request failed",
+  "unable to download video data.",
+  "this video is not available on youtube.",
+  "unable to reach youtube",
+  GENERIC_ERROR_MESSAGE.toLowerCase(),
+]);
+
+const SOURCE_LABELS: Record<string, string> = {
+  youtube: "YouTube",
+  soundcloud: "SoundCloud",
+  bandcamp: "Bandcamp",
+};
+
+function errorMessage(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (value instanceof Error) {
+    return value.message;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  return String(value);
+}
+
+function errorCode(value: unknown): string | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const code = (value as ErrorLike).code;
+  return typeof code === "string" && code.trim() ? code.trim() : null;
+}
+
+export function cleanErrorMessage(value: unknown, fallback = "Loading failed."): string {
+  let message = errorMessage(value).replace(/\s+/g, " ").trim();
+  while (/^error:\s*/i.test(message)) {
+    message = message.replace(/^error:\s*/i, "").trim();
+  }
+  return message || fallback;
+}
+
+function sourceLabel(sourceProvider: string | null | undefined): string | null {
+  if (!sourceProvider) {
+    return null;
+  }
+  return SOURCE_LABELS[sourceProvider.toLowerCase()] ?? null;
+}
+
+function isSourceFetchFailure(message: string, code: string | null): boolean {
+  if (code && FETCH_FAILURE_CODES.has(code)) {
+    return true;
+  }
+  const normalized = message.toLowerCase();
+  if (FETCH_FAILURE_MESSAGES.has(normalized)) {
+    return true;
+  }
+  return normalized.startsWith("request failed (");
+}
+
+export function formatErrorForDisplay(
+  value: unknown,
+  options: ErrorDisplayOptions = {},
+): string {
+  const message = cleanErrorMessage(value, options.fallback);
+  const code = options.errorCode ?? errorCode(value);
+  const label = sourceLabel(options.sourceProvider);
+  if (label && isSourceFetchFailure(message, code)) {
+    return `${label} fetch failed.`;
+  }
+  return message;
+}
+
+export function inferSourceProviderFromUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (/^[a-zA-Z0-9_-]{11}$/.test(trimmed)) {
+    return "youtube";
+  }
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  const host = url.hostname.replace(/^www\./, "").toLowerCase();
+  if (host === "youtu.be" || host.endsWith("youtube.com")) {
+    return "youtube";
+  }
+  if (host.endsWith("soundcloud.com")) {
+    return "soundcloud";
+  }
+  if (host.endsWith("bandcamp.com")) {
+    return "bandcamp";
+  }
+  return null;
+}

--- a/web/src/app/playback.ts
+++ b/web/src/app/playback.ts
@@ -34,12 +34,13 @@ import {
   isAnalysisFailed,
   isAnalysisInProgress,
 } from "./analysisStatus";
+import { formatErrorForDisplay } from "./errorDisplay";
 
 const DEFAULT_VOLUME = 0.5;
 const MAX_RANDOM_BRANCH_DELTA = 0.2;
 const RANDOM_BRANCH_DELTA_PERCENT_SCALE = 100 / MAX_RANDOM_BRANCH_DELTA;
 const GENERIC_LOAD_ERROR_MESSAGE =
-  "ERROR: Something went wrong. Please try again or report an issue on GitHub.";
+  "Something went wrong. Please try again or report an issue on GitHub.";
 
 function getDeletedEdgeIdsFromGraph(
   graph: ReturnType<AppContext["engine"]["getGraphState"]>,
@@ -1191,7 +1192,14 @@ export async function pollAnalysis(
           await loadAudioFromJob(context, jobId);
         }
       } else if (isAnalysisFailed(response)) {
-        deps.setAnalysisStatus(response.error || "Loading failed.", false);
+        deps.setAnalysisStatus(
+          formatErrorForDisplay(response.error, {
+            sourceProvider: response.source_provider,
+            errorCode: response.error_code,
+            fallback: "Loading failed.",
+          }),
+          false,
+        );
         return;
       } else if (isAnalysisComplete(response)) {
         if (!state.audioLoaded) {
@@ -1301,7 +1309,7 @@ async function loadTrack(
         : await fetchAnalysis(source.id);
     await continueTrackLoadWithResponse(context, deps, response);
   } catch (err) {
-    deps.setAnalysisStatus(`Load failed: ${String(err)}`, false);
+    deps.setAnalysisStatus(`Load failed: ${formatErrorForDisplay(err)}`, false);
   }
 }
 

--- a/web/src/app/search.test.ts
+++ b/web/src/app/search.test.ts
@@ -94,6 +94,8 @@ describe("search flows", () => {
       id: "job-f",
       source_id: "yt-f",
       error: "ERROR: [download] This video is not available.",
+      error_code: "download_unavailable",
+      source_provider: "youtube",
     });
     const result = await tryLoadExistingTrackByName(
       context,
@@ -103,7 +105,7 @@ describe("search flows", () => {
     );
     expect(result).toBe(true);
     expect(deps.setAnalysisStatus).toHaveBeenCalledWith(
-      "ERROR: [download] This video is not available.",
+      "YouTube fetch failed.",
       false,
     );
     expect(deps.pollAnalysis).not.toHaveBeenCalled();

--- a/web/src/app/search.ts
+++ b/web/src/app/search.ts
@@ -16,6 +16,7 @@ import {
   isAnalysisFailed,
   isAnalysisInProgress,
 } from "./analysisStatus";
+import { formatErrorForDisplay } from "./errorDisplay";
 
 export type SearchDeps = {
   setActiveTab: (tabId: TabId) => void;
@@ -63,7 +64,7 @@ function isTrackLengthAllowed(
     duration > maxTrackLengthMinutes * 60
   ) {
     deps.showToast(
-      `Error: The maximum track length for this server is ${formatMinutes(maxTrackLengthMinutes)} minutes.`,
+      `The maximum track length for this server is ${formatMinutes(maxTrackLengthMinutes)} minutes.`,
       { icon: "error", tone: "error" },
     );
     return false;
@@ -211,7 +212,8 @@ export async function showYoutubeMatches(
     );
     renderSearchList(elements.searchResults, rows);
   } catch (err) {
-    elements.searchResults.textContent = `YouTube search failed: ${String(err)}`;
+    elements.searchResults.textContent =
+      `YouTube search failed: ${formatErrorForDisplay(err)}`;
     elements.searchHint.textContent = "Step 1: Find a Spotify track.";
   }
 }
@@ -260,7 +262,14 @@ export async function tryLoadExistingTrackByName(
       return true;
     }
     if (isAnalysisFailed(response)) {
-      deps.setAnalysisStatus(response.error || "Loading failed.", false);
+      deps.setAnalysisStatus(
+        formatErrorForDisplay(response.error, {
+          sourceProvider: response.source_provider,
+          errorCode: response.error_code,
+          fallback: "Loading failed.",
+        }),
+        false,
+      );
       return true;
     }
     if (isAnalysisComplete(response)) {
@@ -277,7 +286,8 @@ export async function tryLoadExistingTrackByName(
     await deps.pollAnalysis(jobId);
     return true;
   } catch (err) {
-    elements.searchResults.textContent = `Lookup failed: ${String(err)}`;
+    elements.searchResults.textContent =
+      `Lookup failed: ${formatErrorForDisplay(err)}`;
     return false;
   }
 }
@@ -304,7 +314,8 @@ export async function runSearch(context: AppContext, deps: SearchDeps) {
     const rows = items.map((item) => buildSpotifyMatchItem(context, deps, item));
     renderSearchList(elements.searchResults, rows);
   } catch (err) {
-    elements.searchResults.textContent = `Search failed: ${String(err)}`;
+    elements.searchResults.textContent =
+      `Search failed: ${formatErrorForDisplay(err)}`;
   } finally {
     elements.searchButton.disabled = false;
   }
@@ -335,7 +346,10 @@ function handleYoutubeMatchClick(
     return;
   }
   startYoutubeAnalysisFlow(context, deps, youtubeId, name, artist).catch((err) => {
-    deps.setAnalysisStatus(`YouTube analysis failed: ${String(err)}`, false);
+    deps.setAnalysisStatus(
+      `YouTube analysis failed: ${formatErrorForDisplay(err, { sourceProvider: "youtube" })}`,
+      false,
+    );
   });
 }
 

--- a/web/src/app/wire/playback.ts
+++ b/web/src/app/wire/playback.ts
@@ -6,6 +6,7 @@ import type { JukeboxEngine } from "../../engine";
 import type { JukeboxController } from "../../jukebox/JukeboxController";
 import type { AutocanonizerController } from "../../autocanonizer/AutocanonizerController";
 import type { ToastOptions } from "../ui";
+import { formatErrorForDisplay } from "../errorDisplay";
 import { VISUALIZATION_LABELS } from "../constants";
 import { formatDuration, formatPlaybackTitle } from "../format";
 import { setAutoMarqueeText } from "../marquee";
@@ -479,7 +480,7 @@ export function createPlaybackUiHandlers(deps: PlaybackUiDeps) {
       await navigator.clipboard.writeText(shortUrl);
       showToast(context, "Link copied to clipboard");
     } catch (err) {
-      setAnalysisStatus(context, `Copy failed: ${String(err)}`, false);
+      setAnalysisStatus(context, `Copy failed: ${formatErrorForDisplay(err)}`, false);
     }
   }
 

--- a/web/src/app/wire/search.test.ts
+++ b/web/src/app/wire/search.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppContext, AppState } from "../context";
+import type { Elements } from "../elements";
+import { createSearchHandlers } from "./search";
+
+function createClassList() {
+  return {
+    toggle: vi.fn(),
+  };
+}
+
+function createButton() {
+  return {
+    disabled: false,
+    classList: createClassList(),
+    setAttribute: vi.fn(),
+  } as unknown as HTMLButtonElement;
+}
+
+function createHarness() {
+  const context = {} as AppContext;
+  const elements = {
+    searchButton: createButton(),
+    uploadFileButton: createButton(),
+    uploadYoutubeButton: createButton(),
+    uploadFileInput: { files: null, value: "" },
+    uploadYoutubeInput: { value: "" },
+  } as unknown as Elements;
+  const state = {
+    appConfig: { allow_user_url: true },
+    tuningParams: null,
+    playMode: "jukebox",
+  } as unknown as AppState;
+  const showToast = vi.fn();
+  const startUrlAnalysis = vi.fn();
+  const handlers = createSearchHandlers({
+    context,
+    elements,
+    state,
+    searchDeps: {} as Parameters<typeof createSearchHandlers>[0]["searchDeps"],
+    runSearch: vi.fn(),
+    showToast,
+    uploadAudio: vi.fn(),
+    startUrlAnalysis,
+    resetForNewTrack: vi.fn(),
+    setActiveTabWithRefresh: vi.fn(),
+    setLoadingProgress: vi.fn(),
+    updateTrackUrl: vi.fn(),
+    pollAnalysisJob: vi.fn(),
+  });
+  return { elements, handlers, showToast, startUrlAnalysis };
+}
+
+describe("createSearchHandlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows source-specific SoundCloud errors from URL upload failures", async () => {
+    const { elements, handlers, showToast, startUrlAnalysis } = createHarness();
+    elements.uploadYoutubeInput.value = "https://soundcloud.com/artist/track";
+    startUrlAnalysis.mockRejectedValue(
+      Object.assign(new Error("Error: ERROR: Unable to download video data."), {
+        code: "download_unavailable",
+      }),
+    );
+
+    await handlers.handleUploadYoutubeClick();
+
+    expect(showToast).toHaveBeenCalledWith(
+      expect.anything(),
+      "SoundCloud fetch failed.",
+      { icon: "error", tone: "error" },
+    );
+  });
+
+  it("shows source-specific Bandcamp errors from failed URL responses", async () => {
+    const { elements, handlers, showToast, startUrlAnalysis } = createHarness();
+    elements.uploadYoutubeInput.value = "https://artist.bandcamp.com/track/song";
+    startUrlAnalysis.mockResolvedValue({
+      id: "job-bandcamp",
+      status: "failed",
+      source_provider: "bandcamp",
+      error: "ERROR: Unable to download video data.",
+      error_code: "download_unavailable",
+    });
+
+    await handlers.handleUploadYoutubeClick();
+
+    expect(showToast).toHaveBeenCalledWith(
+      expect.anything(),
+      "Bandcamp fetch failed.",
+      { icon: "error", tone: "error" },
+    );
+  });
+});

--- a/web/src/app/wire/search.ts
+++ b/web/src/app/wire/search.ts
@@ -2,6 +2,10 @@ import type { AppContext, AppState, TabId } from "../context";
 import type { Elements } from "../elements";
 import type { SearchDeps } from "../search";
 import type { ToastOptions } from "../ui";
+import {
+  formatErrorForDisplay,
+  inferSourceProviderFromUrl,
+} from "../errorDisplay";
 
 type SearchHandlersDeps = {
   context: AppContext;
@@ -13,7 +17,14 @@ type SearchHandlersDeps = {
   uploadAudio: (file: File) => Promise<{ id?: string } | null>;
   startUrlAnalysis: (payload: {
     url: string;
-  }) => Promise<{ id?: string; source_id?: string; source_provider?: string } | null>;
+  }) => Promise<{
+    id?: string;
+    source_id?: string;
+    source_provider?: string;
+    status?: string;
+    error?: string;
+    error_code?: string;
+  } | null>;
   resetForNewTrack: (context: AppContext) => void;
   setActiveTabWithRefresh: (tabId: TabId) => void;
   setLoadingProgress: (
@@ -61,7 +72,7 @@ export function createSearchHandlers(deps: SearchHandlersDeps) {
   }
 
   function maxTrackLengthMessage(minutes: number): string {
-    return `Error: The maximum track length for this server is ${formatMinutes(minutes)} minutes.`;
+    return `The maximum track length for this server is ${formatMinutes(minutes)} minutes.`;
   }
 
   function setButtonBusy(button: HTMLButtonElement, busy: boolean) {
@@ -228,10 +239,10 @@ export function createSearchHandlers(deps: SearchHandlersDeps) {
             : null;
         showToast(
           context,
-          (err as Error).message ||
+          formatErrorForDisplay(err) ||
             (fallbackLimit !== null
               ? maxTrackLengthMessage(fallbackLimit)
-              : "Error: This track exceeds the server max track length."),
+              : "This track exceeds the server max track length."),
           {
             icon: "error",
             tone: "error",
@@ -239,7 +250,10 @@ export function createSearchHandlers(deps: SearchHandlersDeps) {
         );
         return;
       }
-      showToast(context, `Upload failed: ${String(err)}`);
+      showToast(context, `Upload failed: ${formatErrorForDisplay(err)}`, {
+        icon: "error",
+        tone: "error",
+      });
     } finally {
       setButtonBusy(elements.uploadFileButton, false);
       uploadFileInFlight = false;
@@ -266,6 +280,7 @@ export function createSearchHandlers(deps: SearchHandlersDeps) {
       showToast(context, "Invalid or unsupported URL.");
       return;
     }
+    const requestedSourceProvider = inferSourceProviderFromUrl(sourceUrl);
     uploadYoutubeInFlight = true;
     setButtonBusy(elements.uploadYoutubeButton, true);
     try {
@@ -274,6 +289,18 @@ export function createSearchHandlers(deps: SearchHandlersDeps) {
       });
       const sourceId = response?.source_id;
       const sourceProvider = response?.source_provider;
+      if (response?.status === "failed") {
+        showToast(
+          context,
+          formatErrorForDisplay(response.error, {
+            sourceProvider: sourceProvider ?? requestedSourceProvider,
+            errorCode: response.error_code,
+            fallback: "Upload failed.",
+          }),
+          { icon: "error", tone: "error" },
+        );
+        return;
+      }
       if (!response || !response.id || !sourceProvider) {
         throw new Error("Upload failed");
       }
@@ -307,10 +334,12 @@ export function createSearchHandlers(deps: SearchHandlersDeps) {
             : null;
         showToast(
           context,
-          (err as Error).message ||
+          formatErrorForDisplay(err, {
+            sourceProvider: requestedSourceProvider,
+          }) ||
             (fallbackLimit !== null
               ? maxTrackLengthMessage(fallbackLimit)
-              : "Error: This track exceeds the server max track length."),
+              : "This track exceeds the server max track length."),
           {
             icon: "error",
             tone: "error",
@@ -318,7 +347,14 @@ export function createSearchHandlers(deps: SearchHandlersDeps) {
         );
         return;
       }
-      showToast(context, `Upload failed: ${String(err)}`);
+      showToast(
+        context,
+        formatErrorForDisplay(err, {
+          sourceProvider: requestedSourceProvider,
+          fallback: "Upload failed.",
+        }),
+        { icon: "error", tone: "error" },
+      );
     } finally {
       setButtonBusy(elements.uploadYoutubeButton, false);
       uploadYoutubeInFlight = false;

--- a/web/src/app/wire/top-songs.ts
+++ b/web/src/app/wire/top-songs.ts
@@ -1,5 +1,6 @@
 import type { Elements } from "../elements";
 import type { TabId } from "../context";
+import { formatErrorForDisplay } from "../errorDisplay";
 type TopSongsDeps = {
   elements: Elements;
   fetchTopSongs: (limit: number) => Promise<
@@ -82,7 +83,8 @@ export function createTopSongsHandlers(deps: TopSongsDeps) {
         listEl.appendChild(li);
       }
     } catch (err) {
-      listEl.textContent = `${errorPrefix} unavailable: ${String(err)}`;
+      listEl.textContent =
+        `${errorPrefix} unavailable: ${formatErrorForDisplay(err)}`;
     }
   }
 

--- a/web/src/cast/main.ts
+++ b/web/src/cast/main.ts
@@ -7,6 +7,7 @@ import { JukeboxEngine } from "../engine";
 import type { JukeboxConfig } from "../engine/types";
 import { JukeboxViz } from "../jukebox/JukeboxViz";
 import { fetchAnalysis, fetchAudio, recordPlay } from "../app/api";
+import { formatErrorForDisplay } from "../app/errorDisplay";
 import { formatDuration } from "../app/format";
 import { applyCastTuningToEngine, parseCastTuningParams } from "./tuning";
 
@@ -295,7 +296,16 @@ async function pollAnalysis(
       throw new Error("Analysis not found");
     }
     if (response.status === "failed") {
-      throw new Error(response.error || "Analysis failed");
+      throw Object.assign(
+        new Error(
+          formatErrorForDisplay(response.error, {
+            sourceProvider: response.source_provider,
+            errorCode: response.error_code,
+            fallback: "Analysis failed.",
+          }),
+        ),
+        { code: response.error_code },
+      );
     }
     if (response.status === "complete") {
       return response;
@@ -923,7 +933,9 @@ async function bootstrap() {
       if (token !== state.loadToken) {
         return;
       }
-      const errorMessage = err instanceof Error ? err.message : "Load failed";
+      const errorMessage = formatErrorForDisplay(err, {
+        fallback: "Load failed.",
+      });
       const errorCode =
         err &&
         typeof err === "object" &&


### PR DESCRIPTION
Implemented the web-only error display cleanup.

Added `errorDisplay` with shared normalization for redundant `Error:` / `ERROR:` prefixes and provider-aware fetch failures. Wired it into web status/toast paths in search, upload URL/file handling, listen polling/load failures, top song list errors, copy-link errors, and cast receiver failures.