### PR TITLE
fix audio graph drift

### DIFF
--- a/pwa/src/shared/jukebox/audio/BufferedAudioPlayer.test.ts
+++ b/pwa/src/shared/jukebox/audio/BufferedAudioPlayer.test.ts
@@ -279,10 +279,10 @@ describe("BufferedAudioPlayer", () => {
     await player.loadBuffer({ duration: 10 } as AudioBuffer);
     player.play();
     expect(context.createdSources).toHaveLength(1);
-    player.scheduleJump(2, 1);
+    expect(player.scheduleJump(2, 1)).toBe(true);
     const firstPending = context.createdSources[1];
     expect(firstPending).toBeDefined();
-    player.scheduleJump(3, 1);
+    expect(player.scheduleJump(3, 1)).toBe(true);
     expect(firstPending?.stop).toHaveBeenCalled();
     expect(firstPending?.disconnect).toHaveBeenCalledTimes(1);
   });
@@ -295,7 +295,7 @@ describe("BufferedAudioPlayer", () => {
     player.play();
     context.currentTime = 10.25;
 
-    player.scheduleJump(2, 1);
+    expect(player.scheduleJump(2, 1)).toBe(true);
 
     expect(context.createdSources).toHaveLength(2);
     expect(context.createdSources[1]?.start).toHaveBeenCalledWith(11, 2, 18);
@@ -310,7 +310,7 @@ describe("BufferedAudioPlayer", () => {
     player.play();
     context.currentTime = 1.01;
 
-    player.scheduleJump(2, 0);
+    expect(player.scheduleJump(2, 0)).toBe(false);
 
     expect(context.createdSources).toHaveLength(1);
     expect(context.createdSources[0]?.stop).not.toHaveBeenCalled();
@@ -322,11 +322,11 @@ describe("BufferedAudioPlayer", () => {
     await player.loadBuffer({ duration: 20 } as AudioBuffer);
     player.play();
     context.currentTime = 0.25;
-    player.scheduleJump(2, 2);
+    expect(player.scheduleJump(2, 2)).toBe(true);
     const pending = context.createdSources[1];
 
     context.currentTime = 0.5;
-    player.scheduleJump(3, 0);
+    expect(player.scheduleJump(3, 0)).toBe(false);
 
     expect(context.createdSources).toHaveLength(2);
     expect(pending?.stop).not.toHaveBeenCalled();
@@ -339,7 +339,7 @@ describe("BufferedAudioPlayer", () => {
     const player = new BufferedAudioPlayer(context as unknown as AudioContext);
     await player.loadBuffer({ duration: 20 } as AudioBuffer);
     player.play();
-    player.scheduleJump(2, 1);
+    expect(player.scheduleJump(2, 1)).toBe(true);
     const pending = context.createdSources[1];
 
     player.cancelScheduledJump();
@@ -354,7 +354,7 @@ describe("BufferedAudioPlayer", () => {
     await player.loadBuffer({ duration: 10 } as AudioBuffer);
     player.play();
     context.currentTime = 0.25;
-    player.scheduleJump(2, 1);
+    expect(player.scheduleJump(2, 1)).toBe(true);
     const original = context.createdSources[0];
     const pending = context.createdSources[1];
 
@@ -375,7 +375,7 @@ describe("BufferedAudioPlayer", () => {
     await player.loadBuffer({ duration: 10 } as AudioBuffer);
     player.play();
     context.currentTime = 0.5;
-    player.scheduleJump(2, 1);
+    expect(player.scheduleJump(2, 1)).toBe(true);
     const pending = context.createdSources[1];
 
     context.currentTime = 1.01;

--- a/pwa/src/shared/jukebox/audio/BufferedAudioPlayer.ts
+++ b/pwa/src/shared/jukebox/audio/BufferedAudioPlayer.ts
@@ -243,13 +243,13 @@ export class BufferedAudioPlayer {
 
   scheduleJump(targetTime: number, sourceStartTime: number) {
     if (!this.buffer || !this.playing) {
-      return;
+      return false;
     }
     const currentSourceTime = this.getCurrentTime();
     const lateBy = currentSourceTime - sourceStartTime;
     const maxLateSeconds = MAX_LATE_JUMP_FRAMES / this.context.sampleRate;
     if (lateBy > maxLateSeconds) {
-      return;
+      return false;
     }
     this.clearPendingSwap();
     const sourceLead = Math.max(0, sourceStartTime - currentSourceTime);
@@ -270,7 +270,12 @@ export class BufferedAudioPlayer {
       }
     };
     const duration = this.buffer.duration - targetTime;
-    source.start(startTime, targetTime, Math.max(0, duration));
+    try {
+      source.start(startTime, targetTime, Math.max(0, duration));
+    } catch {
+      source.disconnect();
+      return false;
+    }
     if (this.source) {
       this.source.onended = null;
       try {
@@ -282,6 +287,7 @@ export class BufferedAudioPlayer {
     this.pendingSource = source;
     this.pendingStartAt = startTime - targetTime / this.playbackRate;
     this.pendingSwapAt = startTime;
+    return true;
   }
 
   cancelScheduledJump() {

--- a/pwa/src/shared/jukebox/engine/JukeboxEngine.test.ts
+++ b/pwa/src/shared/jukebox/engine/JukeboxEngine.test.ts
@@ -44,7 +44,7 @@ function makePlayer(overrides: Partial<JukeboxPlayer> = {}): JukeboxPlayer {
     pause: vi.fn(),
     stop: vi.fn(),
     seek: vi.fn(),
-    scheduleJump: vi.fn(),
+    scheduleJump: vi.fn(() => true),
     cancelScheduledJump: vi.fn(),
     getCurrentTime: () => 0,
     getAudioTime: () => 0,
@@ -92,6 +92,7 @@ function installEngineState(
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -122,6 +123,81 @@ describe("PWA JukeboxEngine jump scheduling parity", () => {
 
     expect(player.scheduleJump).toHaveBeenCalledTimes(1);
     expect(player.scheduleJump).toHaveBeenCalledWith(0, 1);
+  });
+
+  it("keeps the graph sequential when the audio jump cannot be scheduled", () => {
+    const player = makePlayer({
+      scheduleJump: vi.fn(() => false),
+    });
+    const engine = new JukeboxEngine(player, { randomMode: "seeded", seed: 1 });
+    const beats = [0, 1, 2].map(makeBeat);
+    linkBeats(beats);
+    const edge: Edge = {
+      id: 0,
+      src: beats[1],
+      dest: beats[0],
+      distance: 10,
+      deleted: false,
+    };
+    beats[1].neighbors = [edge];
+    beats[1].allNeighbors = [edge];
+    const engineAny = installEngineState(
+      engine,
+      beats,
+      makeGraph(beats, edge),
+      0,
+      10.75,
+    );
+
+    engineAny.advanceBeat(engineAny.nextAudioTime);
+
+    expect(player.scheduleJump).toHaveBeenCalledWith(0, 1);
+    expect(engineAny.currentBeatIndex).toBe(1);
+  });
+
+  it("resyncs to the actual audio beat after a delayed tick replays stale branch state", () => {
+    vi.useFakeTimers();
+    let audioNow = 0.5;
+    let trackNow = 0.5;
+    const player = makePlayer({
+      getAudioTime: () => audioNow,
+      getCurrentTime: () => trackNow,
+    });
+    const engine = new JukeboxEngine(player, { randomMode: "seeded", seed: 1 });
+    const beats = [0, 1, 2].map(makeBeat);
+    linkBeats(beats);
+    const edge: Edge = {
+      id: 0,
+      src: beats[1],
+      dest: beats[0],
+      distance: 10,
+      deleted: false,
+    };
+    beats[1].neighbors = [edge];
+    beats[1].allNeighbors = [edge];
+    const engineAny = installEngineState(
+      engine,
+      beats,
+      makeGraph(beats, edge),
+      0,
+      1,
+    ) as ReturnType<typeof installEngineState> & {
+      lastJumpFromIndex: number | null;
+      ticking: boolean;
+      tick: () => void;
+    };
+    engineAny.ticking = true;
+    engineAny.preparePendingAdvance(engineAny.nextAudioTime);
+
+    audioNow = 1.2;
+    trackNow = 1.2;
+    engineAny.tick();
+
+    expect(player.scheduleJump).toHaveBeenCalledWith(0, 1);
+    expect(engineAny.currentBeatIndex).toBe(1);
+    expect(engineAny.nextAudioTime).toBeCloseTo(2, 5);
+    expect(engineAny.lastJumpFromIndex).toBe(null);
+    engine.stopJukebox();
   });
 
   it("uses the final beat end as the source boundary when wrapping", () => {

--- a/pwa/src/shared/jukebox/engine/JukeboxEngine.ts
+++ b/pwa/src/shared/jukebox/engine/JukeboxEngine.ts
@@ -35,6 +35,7 @@ const DEFAULT_CONFIG: JukeboxConfig = {
 
 const TICK_INTERVAL_MS = 50;
 const MIN_JUMP_SCHEDULE_LEAD_SECONDS = 0.08;
+const PLAYBACK_SYNC_TOLERANCE_SECONDS = 0.25;
 
 type UpdateListener = (state: JukeboxState) => void;
 
@@ -58,7 +59,7 @@ export interface JukeboxPlayer {
   pause: () => void;
   stop: () => void;
   seek: (time: number) => void;
-  scheduleJump: (targetTime: number, sourceStartTime: number) => void;
+  scheduleJump: (targetTime: number, sourceStartTime: number) => boolean;
   cancelScheduledJump: () => void;
   getCurrentTime: () => number;
   getAudioTime: () => number;
@@ -458,6 +459,7 @@ export class JukeboxEngine {
     if (!this.ticking) {
       return;
     }
+    this.ensureSyncedToPlaybackPosition(audioTime);
 
     this.emitState(this.lastJumped);
     this.lastJumped = false;
@@ -527,10 +529,12 @@ export class JukeboxEngine {
     let shouldJump = false;
     let jumpFromIndex: number | null = null;
     let sourceBoundaryTime: number | null = null;
+    let sequentialIndex = 0;
 
     if (currentIndex >= 0) {
       const nextIndex = currentIndex + 1;
       const wrappedIndex = nextIndex >= beatsCount ? 0 : nextIndex;
+      sequentialIndex = wrappedIndex;
       if (this.bringItHomeMode) {
         chosenIndex = wrappedIndex;
       } else {
@@ -580,7 +584,21 @@ export class JukeboxEngine {
     }
     const targetTime = shouldJump ? targetBeat.start : null;
     if (scheduleJump && targetTime !== null && sourceBoundaryTime !== null) {
-      this.player.scheduleJump(targetTime, sourceBoundaryTime);
+      const scheduled = this.player.scheduleJump(targetTime, sourceBoundaryTime);
+      if (!scheduled) {
+        const sequentialBeat = this.beats[sequentialIndex];
+        if (!sequentialBeat) {
+          return null;
+        }
+        return {
+          boundaryAudioTime,
+          chosenIndex: sequentialIndex,
+          shouldJump: false,
+          targetTime: null,
+          jumpFromIndex: null,
+          sourceBoundaryTime: null,
+        };
+      }
     }
     return {
       boundaryAudioTime,
@@ -627,6 +645,39 @@ export class JukeboxEngine {
     this.currentBeatIndex = beatIndex;
     this.beatsPlayed = Math.max(this.beatsPlayed, beatIndex + 1);
     this.nextAudioTime = audioTime + remainingInBeat / this.getPlaybackRate();
+  }
+
+  private ensureSyncedToPlaybackPosition(audioTime: number) {
+    if (this.currentBeatIndex < 0) {
+      return;
+    }
+    const trackTime = this.player.getCurrentTime();
+    const beatIndex = this.findBeatIndexByTime(trackTime);
+    if (beatIndex < 0 || beatIndex >= this.beats.length) {
+      return;
+    }
+    const beat = this.beats[beatIndex];
+    const elapsedInBeat = Math.max(
+      0,
+      Math.min(beat.duration, trackTime - beat.start),
+    );
+    const remainingInBeat = Math.max(0, beat.duration - elapsedInBeat);
+    const expectedNextAudioTime =
+      audioTime + remainingInBeat / this.getPlaybackRate();
+    const beatMismatch = beatIndex !== this.currentBeatIndex;
+    const boundaryMismatch =
+      Math.abs(this.nextAudioTime - expectedNextAudioTime) >
+      PLAYBACK_SYNC_TOLERANCE_SECONDS;
+    if (!beatMismatch && !boundaryMismatch) {
+      return;
+    }
+    this.currentBeatIndex = beatIndex;
+    this.nextAudioTime = expectedNextAudioTime;
+    this.lastJumped = false;
+    this.lastJumpTime = null;
+    this.lastJumpFromIndex = null;
+    this.branchState.lastDestBySource = null;
+    this.clearPendingAdvance(true);
   }
 
   private clearPendingAdvance(cancelScheduledJump: boolean) {

--- a/pwa/src/shared/jukebox/engine/deleteResetParityFixtures.test.ts
+++ b/pwa/src/shared/jukebox/engine/deleteResetParityFixtures.test.ts
@@ -64,7 +64,7 @@ function makePlayer(): JukeboxPlayer {
     pause: vi.fn(),
     stop: vi.fn(),
     seek: vi.fn(),
-    scheduleJump: vi.fn(),
+    scheduleJump: vi.fn(() => true),
     cancelScheduledJump: vi.fn(),
     getCurrentTime: () => 0,
     getAudioTime: () => 0,

--- a/pwa/src/shared/jukebox/engine/selection.test.ts
+++ b/pwa/src/shared/jukebox/engine/selection.test.ts
@@ -59,7 +59,9 @@ describe("PWA branch ramp parity", () => {
       pause() {},
       stop() {},
       seek(_time: number) {},
-      scheduleJump(_targetTime: number, _audioStart: number) {},
+      scheduleJump(_targetTime: number, _audioStart: number) {
+        return true;
+      },
       cancelScheduledJump() {},
       getCurrentTime() {
         return 0;
@@ -135,7 +137,9 @@ describe("PWA branch ramp parity", () => {
       pause() {},
       stop() {},
       seek(_time: number) {},
-      scheduleJump(_targetTime: number, _audioStart: number) {},
+      scheduleJump(_targetTime: number, _audioStart: number) {
+        return true;
+      },
       cancelScheduledJump() {},
       getCurrentTime() {
         return 0;

--- a/web/src/app/playback.test.ts
+++ b/web/src/app/playback.test.ts
@@ -6,6 +6,7 @@ import {
   applyAnalysisResult,
   getActiveTuningTab,
   resetExtrasDefaults,
+  resetTuningDefaults,
   applyTuningChanges,
   loadAudioFromJob,
   loadTrackById,
@@ -300,6 +301,7 @@ function createContext(overrides?: Partial<AppContext>): AppContext {
   const player = {
     getVolume: vi.fn(() => 0.5),
     getDuration: vi.fn(() => null),
+    setVolume: vi.fn(),
     play: vi.fn(),
     isPlaying: vi.fn(() => true),
     pause: vi.fn(),
@@ -617,6 +619,22 @@ describe("playback tuning", () => {
     expect(context.state.jukeboxAudioMode).toBe("off");
     expect(context.cowbellOverlay.disable).toHaveBeenCalledTimes(1);
     expect(context.elements.branchStatsPopup.classList.add).toHaveBeenCalledWith("hidden");
+  });
+
+  it("preserves audio mode URL param when tuning reset clears other tuning params", () => {
+    setWindowUrl("http://localhost/listen/abc?jb=1&thresh=30&ab=7&am=daycore");
+    const context = createContext();
+    context.state.tuningParams = "jb=1&thresh=30&ab=7&am=daycore";
+    context.state.jukeboxAudioMode = "daycore";
+    context.engine.setUserAnchorEdge(
+      { id: 7 } as Parameters<AppContext["engine"]["setUserAnchorEdge"]>[0],
+    );
+
+    resetTuningDefaults(context);
+
+    expect(context.state.tuningParams).toBe("am=daycore");
+    expect(window.location.search).toBe("?am=daycore");
+    expect(context.state.jukeboxAudioMode).toBe("daycore");
   });
 
   it("resets audio mode on track change", () => {

--- a/web/src/app/playback.ts
+++ b/web/src/app/playback.ts
@@ -790,8 +790,11 @@ export function resetTuningDefaults(context: AppContext) {
   state.autoComputedThreshold = graph
     ? Math.round(graph.currentThreshold)
     : null;
-  state.tuningParams = null;
-  writeTuningParamsToUrl(null, true);
+  state.tuningParams =
+    state.jukeboxAudioMode === "off"
+      ? null
+      : new URLSearchParams({ am: state.jukeboxAudioMode }).toString();
+  writeTuningParamsToUrl(state.tuningParams, true);
   player.setVolume(DEFAULT_VOLUME);
   autocanonizer.setVolume(DEFAULT_VOLUME);
   cowbellOverlay.setVolume(DEFAULT_VOLUME);

--- a/web/src/audio/BufferedAudioPlayer.test.ts
+++ b/web/src/audio/BufferedAudioPlayer.test.ts
@@ -283,10 +283,10 @@ describe("BufferedAudioPlayer", () => {
     await player.loadBuffer({ duration: 10 } as AudioBuffer);
     player.play();
     expect(context.createdSources).toHaveLength(1);
-    player.scheduleJump(2, 1);
+    expect(player.scheduleJump(2, 1)).toBe(true);
     const firstPending = context.createdSources[1];
     expect(firstPending).toBeDefined();
-    player.scheduleJump(3, 1);
+    expect(player.scheduleJump(3, 1)).toBe(true);
     expect(firstPending?.stop).toHaveBeenCalled();
     expect(firstPending?.disconnect).toHaveBeenCalledTimes(1);
   });
@@ -299,7 +299,7 @@ describe("BufferedAudioPlayer", () => {
     player.play();
     context.currentTime = 10.25;
 
-    player.scheduleJump(2, 1);
+    expect(player.scheduleJump(2, 1)).toBe(true);
 
     expect(context.createdSources).toHaveLength(2);
     expect(context.createdSources[1]?.start).toHaveBeenCalledWith(11, 2, 18);
@@ -314,7 +314,7 @@ describe("BufferedAudioPlayer", () => {
     player.play();
     context.currentTime = 1.01;
 
-    player.scheduleJump(2, 0);
+    expect(player.scheduleJump(2, 0)).toBe(false);
 
     expect(context.createdSources).toHaveLength(1);
     expect(context.createdSources[0]?.stop).not.toHaveBeenCalled();
@@ -326,11 +326,11 @@ describe("BufferedAudioPlayer", () => {
     await player.loadBuffer({ duration: 20 } as AudioBuffer);
     player.play();
     context.currentTime = 0.25;
-    player.scheduleJump(2, 2);
+    expect(player.scheduleJump(2, 2)).toBe(true);
     const pending = context.createdSources[1];
 
     context.currentTime = 0.5;
-    player.scheduleJump(3, 0);
+    expect(player.scheduleJump(3, 0)).toBe(false);
 
     expect(context.createdSources).toHaveLength(2);
     expect(pending?.stop).not.toHaveBeenCalled();
@@ -343,7 +343,7 @@ describe("BufferedAudioPlayer", () => {
     const player = new BufferedAudioPlayer(context as unknown as AudioContext);
     await player.loadBuffer({ duration: 20 } as AudioBuffer);
     player.play();
-    player.scheduleJump(2, 1);
+    expect(player.scheduleJump(2, 1)).toBe(true);
     const pending = context.createdSources[1];
 
     player.cancelScheduledJump();
@@ -358,7 +358,7 @@ describe("BufferedAudioPlayer", () => {
     await player.loadBuffer({ duration: 10 } as AudioBuffer);
     player.play();
     context.currentTime = 0.25;
-    player.scheduleJump(2, 1);
+    expect(player.scheduleJump(2, 1)).toBe(true);
     const original = context.createdSources[0];
     const pending = context.createdSources[1];
 
@@ -379,7 +379,7 @@ describe("BufferedAudioPlayer", () => {
     await player.loadBuffer({ duration: 10 } as AudioBuffer);
     player.play();
     context.currentTime = 0.5;
-    player.scheduleJump(2, 1);
+    expect(player.scheduleJump(2, 1)).toBe(true);
     const pending = context.createdSources[1];
 
     context.currentTime = 1.01;

--- a/web/src/audio/BufferedAudioPlayer.ts
+++ b/web/src/audio/BufferedAudioPlayer.ts
@@ -316,13 +316,13 @@ export class BufferedAudioPlayer {
 
   scheduleJump(targetTime: number, sourceStartTime: number) {
     if (!this.buffer || !this.playing) {
-      return;
+      return false;
     }
     const currentSourceTime = this.getCurrentTime();
     const lateBy = currentSourceTime - sourceStartTime;
     const maxLateSeconds = MAX_LATE_JUMP_FRAMES / this.context.sampleRate;
     if (lateBy > maxLateSeconds) {
-      return;
+      return false;
     }
     this.clearPendingSwap();
     const sourceLead = Math.max(0, sourceStartTime - currentSourceTime);
@@ -343,7 +343,12 @@ export class BufferedAudioPlayer {
       }
     };
     const duration = this.buffer.duration - targetTime;
-    source.start(startTime, targetTime, Math.max(0, duration));
+    try {
+      source.start(startTime, targetTime, Math.max(0, duration));
+    } catch {
+      source.disconnect();
+      return false;
+    }
     if (this.source) {
       this.source.onended = null;
       try {
@@ -355,6 +360,7 @@ export class BufferedAudioPlayer {
     this.pendingSource = source;
     this.pendingStartAt = startTime - targetTime / this.playbackRate;
     this.pendingSwapAt = startTime;
+    return true;
   }
 
   cancelScheduledJump() {

--- a/web/src/engine/JukeboxEngine.rebuild.test.ts
+++ b/web/src/engine/JukeboxEngine.rebuild.test.ts
@@ -27,7 +27,7 @@ function makePlayer(): JukeboxPlayer {
     pause: vi.fn(),
     stop: vi.fn(),
     seek: vi.fn(),
-    scheduleJump: vi.fn(),
+    scheduleJump: vi.fn(() => true),
     cancelScheduledJump: vi.fn(),
     getCurrentTime: () => 0,
     getAudioTime: () => 0,

--- a/web/src/engine/JukeboxEngine.test.ts
+++ b/web/src/engine/JukeboxEngine.test.ts
@@ -83,7 +83,7 @@ function makePlayer(): JukeboxPlayer {
     pause: vi.fn(),
     stop: vi.fn(),
     seek: vi.fn(),
-    scheduleJump: vi.fn(),
+    scheduleJump: vi.fn(() => true),
     cancelScheduledJump: vi.fn(),
     getCurrentTime: () => 0,
     getAudioTime: () => 0,
@@ -216,6 +216,54 @@ describe("JukeboxEngine branching", () => {
     expect(player.scheduleJump).toHaveBeenCalledTimes(1);
     expect(player.scheduleJump).toHaveBeenCalledWith(0, 1);
     expect(engineAny.lastJumpFromIndex).toBe(1);
+  });
+
+  it("keeps the graph sequential when the audio jump cannot be scheduled", () => {
+    const player = makePlayer();
+    (player.scheduleJump as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    const engine = new JukeboxEngine(player, { randomMode: "seeded", seed: 1 });
+    const beats = [0, 1, 2].map(makeBeat);
+    linkBeats(beats);
+    const edge: Edge = {
+      id: 0,
+      src: beats[1],
+      dest: beats[0],
+      distance: 10,
+      deleted: false,
+    };
+    beats[1].neighbors = [edge];
+    beats[1].allNeighbors = [edge];
+    const graph: JukeboxGraphState = {
+      computedThreshold: 0,
+      currentThreshold: 0,
+      lastBranchPoint: 1,
+      totalBeats: beats.length,
+      longestReach: 0,
+      allEdges: [edge],
+    };
+
+    const engineAny = engine as unknown as {
+      analysis: TrackAnalysis;
+      graph: JukeboxGraphState;
+      beats: QuantumBase[];
+      currentBeatIndex: number;
+      nextAudioTime: number;
+      curRandomBranchChance: number;
+      lastJumpFromIndex: number | null;
+      advanceBeat: (audioTime: number) => void;
+    };
+    engineAny.analysis = makeAnalysis(beats);
+    engineAny.graph = graph;
+    engineAny.beats = beats;
+    engineAny.currentBeatIndex = 0;
+    engineAny.nextAudioTime = 1;
+    engineAny.curRandomBranchChance = engine.getConfig().minRandomBranchChance;
+
+    engineAny.advanceBeat(engineAny.nextAudioTime);
+
+    expect(player.scheduleJump).toHaveBeenCalledWith(0, 1);
+    expect(engineAny.currentBeatIndex).toBe(1);
+    expect(engineAny.lastJumpFromIndex).toBe(null);
   });
 
   it("schedules a jump when wrapping past the last beat", () => {
@@ -368,6 +416,7 @@ describe("JukeboxEngine playback loop", () => {
     let audioNow = 0;
     const player = makePlayer();
     player.getAudioTime = () => audioNow;
+    player.getCurrentTime = () => audioNow;
     const engine = new JukeboxEngine(player, {
       config: {
         minRandomBranchChance: 0,
@@ -395,6 +444,70 @@ describe("JukeboxEngine playback loop", () => {
     audioNow = 2.4;
     engineAny.tick();
     expect(engineAny.currentBeatIndex).toBe(2);
+    engine.stopJukebox();
+  });
+
+  it("resyncs to the actual audio beat after a delayed tick replays stale branch state", () => {
+    vi.useFakeTimers();
+    if ("window" in globalThis) {
+      const win = globalThis.window as { setTimeout: typeof setTimeout; clearTimeout: typeof clearTimeout };
+      win.setTimeout = globalThis.setTimeout;
+      win.clearTimeout = globalThis.clearTimeout;
+    }
+    let audioNow = 0.5;
+    let trackNow = 0.5;
+    const player = makePlayer();
+    player.getAudioTime = () => audioNow;
+    player.getCurrentTime = () => trackNow;
+    const engine = new JukeboxEngine(player, { randomMode: "seeded", seed: 1 });
+    const beats = [0, 1, 2].map(makeBeat);
+    linkBeats(beats);
+    const edge: Edge = {
+      id: 0,
+      src: beats[1],
+      dest: beats[0],
+      distance: 10,
+      deleted: false,
+    };
+    beats[1].neighbors = [edge];
+    beats[1].allNeighbors = [edge];
+    const graph: JukeboxGraphState = {
+      computedThreshold: 0,
+      currentThreshold: 0,
+      lastBranchPoint: 1,
+      totalBeats: beats.length,
+      longestReach: 0,
+      allEdges: [edge],
+    };
+    const engineAny = engine as unknown as {
+      analysis: TrackAnalysis;
+      graph: JukeboxGraphState;
+      beats: QuantumBase[];
+      currentBeatIndex: number;
+      nextAudioTime: number;
+      curRandomBranchChance: number;
+      lastJumpFromIndex: number | null;
+      ticking: boolean;
+      preparePendingAdvance: (audioTime: number) => void;
+      tick: () => void;
+    };
+    engineAny.analysis = makeAnalysis(beats);
+    engineAny.graph = graph;
+    engineAny.beats = beats;
+    engineAny.currentBeatIndex = 0;
+    engineAny.nextAudioTime = 1;
+    engineAny.curRandomBranchChance = engine.getConfig().minRandomBranchChance;
+    engineAny.ticking = true;
+    engineAny.preparePendingAdvance(engineAny.nextAudioTime);
+
+    audioNow = 1.2;
+    trackNow = 1.2;
+    engineAny.tick();
+
+    expect(player.scheduleJump).toHaveBeenCalledWith(0, 1);
+    expect(engineAny.currentBeatIndex).toBe(1);
+    expect(engineAny.nextAudioTime).toBeCloseTo(2, 5);
+    expect(engineAny.lastJumpFromIndex).toBe(null);
     engine.stopJukebox();
   });
 
@@ -1072,6 +1185,7 @@ describe("JukeboxEngine jump timing", () => {
     let audioNow = 0.94;
     const player = makePlayer();
     player.getAudioTime = () => audioNow;
+    player.getCurrentTime = () => audioNow;
     const engine = new JukeboxEngine(player, {
       config: {
         minRandomBranchChance: 0,

--- a/web/src/engine/JukeboxEngine.ts
+++ b/web/src/engine/JukeboxEngine.ts
@@ -35,6 +35,7 @@ export const DEFAULT_JUKEBOX_CONFIG: JukeboxConfig = {
 
 const TICK_INTERVAL_MS = 50;
 const MIN_JUMP_SCHEDULE_LEAD_SECONDS = 0.08;
+const PLAYBACK_SYNC_TOLERANCE_SECONDS = 0.25;
 
 type UpdateListener = (state: JukeboxState) => void;
 
@@ -58,7 +59,7 @@ export interface JukeboxPlayer {
   pause: () => void;
   stop: () => void;
   seek: (time: number) => void;
-  scheduleJump: (targetTime: number, sourceStartTime: number) => void;
+  scheduleJump: (targetTime: number, sourceStartTime: number) => boolean;
   cancelScheduledJump: () => void;
   getCurrentTime: () => number;
   getAudioTime: () => number;
@@ -458,6 +459,7 @@ export class JukeboxEngine {
     if (!this.ticking) {
       return;
     }
+    this.ensureSyncedToPlaybackPosition(audioTime);
 
     this.emitState(this.lastJumped);
     this.lastJumped = false;
@@ -527,10 +529,12 @@ export class JukeboxEngine {
     let shouldJump = false;
     let jumpFromIndex: number | null = null;
     let sourceBoundaryTime: number | null = null;
+    let sequentialIndex = 0;
 
     if (currentIndex >= 0) {
       const nextIndex = currentIndex + 1;
       const wrappedIndex = nextIndex >= beatsCount ? 0 : nextIndex;
+      sequentialIndex = wrappedIndex;
       if (this.bringItHomeMode) {
         chosenIndex = wrappedIndex;
       } else {
@@ -580,7 +584,21 @@ export class JukeboxEngine {
     }
     const targetTime = shouldJump ? targetBeat.start : null;
     if (scheduleJump && targetTime !== null && sourceBoundaryTime !== null) {
-      this.player.scheduleJump(targetTime, sourceBoundaryTime);
+      const scheduled = this.player.scheduleJump(targetTime, sourceBoundaryTime);
+      if (!scheduled) {
+        const sequentialBeat = this.beats[sequentialIndex];
+        if (!sequentialBeat) {
+          return null;
+        }
+        return {
+          boundaryAudioTime,
+          chosenIndex: sequentialIndex,
+          shouldJump: false,
+          targetTime: null,
+          jumpFromIndex: null,
+          sourceBoundaryTime: null,
+        };
+      }
     }
     return {
       boundaryAudioTime,
@@ -627,6 +645,39 @@ export class JukeboxEngine {
     this.currentBeatIndex = beatIndex;
     this.beatsPlayed = Math.max(this.beatsPlayed, beatIndex + 1);
     this.nextAudioTime = audioTime + remainingInBeat / this.getPlaybackRate();
+  }
+
+  private ensureSyncedToPlaybackPosition(audioTime: number) {
+    if (this.currentBeatIndex < 0) {
+      return;
+    }
+    const trackTime = this.player.getCurrentTime();
+    const beatIndex = this.findBeatIndexByTime(trackTime);
+    if (beatIndex < 0 || beatIndex >= this.beats.length) {
+      return;
+    }
+    const beat = this.beats[beatIndex];
+    const elapsedInBeat = Math.max(
+      0,
+      Math.min(beat.duration, trackTime - beat.start),
+    );
+    const remainingInBeat = Math.max(0, beat.duration - elapsedInBeat);
+    const expectedNextAudioTime =
+      audioTime + remainingInBeat / this.getPlaybackRate();
+    const beatMismatch = beatIndex !== this.currentBeatIndex;
+    const boundaryMismatch =
+      Math.abs(this.nextAudioTime - expectedNextAudioTime) >
+      PLAYBACK_SYNC_TOLERANCE_SECONDS;
+    if (!beatMismatch && !boundaryMismatch) {
+      return;
+    }
+    this.currentBeatIndex = beatIndex;
+    this.nextAudioTime = expectedNextAudioTime;
+    this.lastJumped = false;
+    this.lastJumpTime = null;
+    this.lastJumpFromIndex = null;
+    this.branchState.lastDestBySource = null;
+    this.clearPendingAdvance(true);
   }
 
   private clearPendingAdvance(cancelScheduledJump: boolean) {

--- a/web/src/engine/deleteResetParityFixtures.test.ts
+++ b/web/src/engine/deleteResetParityFixtures.test.ts
@@ -64,7 +64,7 @@ function makePlayer(): JukeboxPlayer {
     pause: vi.fn(),
     stop: vi.fn(),
     seek: vi.fn(),
-    scheduleJump: vi.fn(),
+    scheduleJump: vi.fn(() => true),
     cancelScheduledJump: vi.fn(),
     getCurrentTime: () => 0,
     getAudioTime: () => 0,

--- a/web/src/engine/pathReproParityFixtures.test.ts
+++ b/web/src/engine/pathReproParityFixtures.test.ts
@@ -93,7 +93,7 @@ function makePlayer(): JukeboxPlayer {
     pause: vi.fn(),
     stop: vi.fn(),
     seek: vi.fn(),
-    scheduleJump: vi.fn(),
+    scheduleJump: vi.fn(() => true),
     cancelScheduledJump: vi.fn(),
     getCurrentTime: () => 0,
     getAudioTime: () => 0,

--- a/web/src/engine/rebuildParityFixtures.test.ts
+++ b/web/src/engine/rebuildParityFixtures.test.ts
@@ -56,7 +56,7 @@ function makePlayer(): JukeboxPlayer {
     pause: vi.fn(),
     stop: vi.fn(),
     seek: vi.fn(),
-    scheduleJump: vi.fn(),
+    scheduleJump: vi.fn(() => true),
     cancelScheduledJump: vi.fn(),
     getCurrentTime: () => 0,
     getAudioTime: () => 0,


### PR DESCRIPTION
- Under heavy loads the timer can get throttled and the audio/graph can get out of sync
- Ensure we are synced to the correct playback position