### PR TITLE
harden SQLite job queue concurrency

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -53,5 +53,11 @@ docker run \
 Notes:
 
 - The API serves the web UI at `/`, the offline PWA at `/offline/`, and JSON at `/api/*`.
-- Persist `api/storage/` with a volume (EBS/EFS on AWS); container storage is ephemeral.
+- Persist `api/storage/` with a local or block-backed volume; container storage is ephemeral.
+- `WORKER_COUNT` can be raised for one app instance on a local/container volume; `6`
+  is a reasonable modest-concurrency target. Use a real queue/database instead of
+  SQLite for multiple app containers sharing job state, NFS-style shared filesystems,
+  or high write concurrency.
+- Do not delete `jobs.db-journal`, `jobs.db-wal`, or `jobs.db-shm` while the app is
+  running. Stop the API and workers first so SQLite can finish recovery/checkpointing.
 - Dependency updates (`yt-dlp`, `madmom-beats-lite`, `deno`) happen during image build/deploy; container startup performs no network updates.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Optional:
 - `YOUTUBE_API_KEY`: optional fallback for `/api/search/youtube` when `yt-dlp` search fails.
 - `ADMIN_KEY`: optional; required only for admin-only actions (play-count updates, and deletes outside the 30-minute grace window). Send it via `X-Admin-Key` request header.
 - `NTFY_TOPIC_KEY`: optional; enables ntfy alerts for YouTube download errors.
-- `WORKER_COUNT`: optional; defaults to `1` and controls worker concurrency.
+- `WORKER_COUNT`: optional; defaults to `1` and controls worker concurrency. A single
+  instance on a local/container volume supports modest concurrency such as `6`; do not
+  point multiple running app instances at the same `jobs.db`.
 - `MAX_TRACK_LENGTH`: optional; when set to a positive number (minutes), rejects jobs over that duration.
 - `MAX_FAVORITES`: optional; defaults to `150` and controls the maximum favorites sync payload size.
 - `ALLOW_USER_UPLOAD`: optional; defaults to `false`. Set `true` to enable `/api/upload`.

--- a/api/README.md
+++ b/api/README.md
@@ -226,3 +226,9 @@ Jobs and analysis outputs are stored under `storage/` in this repo:
 - `storage/logs/` - failure logs (engine output or download errors)
 - `storage/jobs.db`
 - `storage/favorites.db`
+
+SQLite queueing is intended for one API/worker instance using a local or container
+volume. Modest worker concurrency such as `WORKER_COUNT=6` is supported, but do not
+share one `jobs.db` across multiple running app containers or NFS-style filesystems.
+Do not delete SQLite sidecar files such as `jobs.db-journal`, `jobs.db-wal`, or
+`jobs.db-shm` while the app is running.

--- a/api/api/db.py
+++ b/api/api/db.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import logging
+import random
 import sqlite3
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -11,6 +14,15 @@ from typing import Optional
 from urllib.parse import urlsplit, urlunsplit
 
 from .db_migrations import run_migrations
+
+logger = logging.getLogger("foreverjukebox.api.db")
+
+SQLITE_CONNECT_TIMEOUT_S = 30.0
+SQLITE_BUSY_TIMEOUT_MS = 30_000
+CLAIM_LOCK_BUSY_TIMEOUT_MS = 250
+CLAIM_LOCK_RETRY_COUNT = 5
+CLAIM_LOCK_RETRY_BASE_S = 0.05
+CLAIM_LOCK_RETRY_MAX_S = 0.75
 
 
 @dataclass
@@ -92,6 +104,30 @@ def _safe_int(value: object, default: int = 0) -> int:
 
 def _clamp_progress(value: object) -> int:
     return max(0, min(100, _safe_int(value, 0)))
+
+
+def _connect(
+    db_path: Path,
+    *,
+    timeout_s: float = SQLITE_CONNECT_TIMEOUT_S,
+    busy_timeout_ms: int = SQLITE_BUSY_TIMEOUT_MS,
+) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path, timeout=timeout_s)
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(f"PRAGMA busy_timeout = {int(busy_timeout_ms)}")
+    return conn
+
+
+def _is_sqlite_lock_error(exc: BaseException) -> bool:
+    if not isinstance(exc, sqlite3.OperationalError):
+        return False
+    message = str(exc).lower()
+    return "database is locked" in message or "database table is locked" in message
+
+
+def _sleep_for_claim_retry(attempt: int) -> None:
+    delay = min(CLAIM_LOCK_RETRY_MAX_S, CLAIM_LOCK_RETRY_BASE_S * (2**attempt))
+    time.sleep(delay + random.uniform(0.0, CLAIM_LOCK_RETRY_BASE_S))
 
 
 def _provider_for_url(source_url: str | None) -> str | None:
@@ -189,7 +225,12 @@ def _source_ref_for(
 
 def init_db(db_path: Path) -> None:
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
+        except sqlite3.OperationalError as exc:
+            logger.warning("SQLite WAL setup failed for %s; continuing with default journal mode: %s", db_path, exc)
         run_migrations(conn)
         conn.commit()
 
@@ -225,13 +266,8 @@ def _upsert_source_for_job(
     source_fallback: str,
 ) -> str:
     now = _utc_now()
-    existing = _lookup_source_for_job(
-        conn,
-        provider=provider,
-        source_id=source_id,
-        source_url=source_url,
-    )
-    if existing:
+
+    def update_existing(existing: tuple[str, str | None, str | None, str | None]) -> str:
         source_ref = str(existing[0])
         existing_url = _clean_text(existing[1])
         existing_title = _clean_text(existing[2])
@@ -249,6 +285,15 @@ def _upsert_source_for_job(
         )
         return source_ref
 
+    existing = _lookup_source_for_job(
+        conn,
+        provider=provider,
+        source_id=source_id,
+        source_url=source_url,
+    )
+    if existing:
+        return update_existing(existing)
+
     base_ref = _source_ref_for(provider, source_id, source_url, source_fallback)
     source_ref = base_ref
     suffix = 2
@@ -256,26 +301,37 @@ def _upsert_source_for_job(
         source_ref = f"{base_ref}_{suffix}"
         suffix += 1
 
-    conn.execute(
-        """
-        INSERT INTO sources (
-            id, provider, source_id, source_url,
-            track_title, track_artist, play_count,
-            created_at, updated_at
+    try:
+        conn.execute(
+            """
+            INSERT INTO sources (
+                id, provider, source_id, source_url,
+                track_title, track_artist, play_count,
+                created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)
+            """,
+            (
+                source_ref,
+                provider,
+                source_id,
+                source_url,
+                track_title,
+                track_artist if track_artist is not None else "",
+                now,
+                now,
+            ),
         )
-        VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)
-        """,
-        (
-            source_ref,
-            provider,
-            source_id,
-            source_url,
-            track_title,
-            track_artist if track_artist is not None else "",
-            now,
-            now,
-        ),
-    )
+    except sqlite3.IntegrityError:
+        existing = _lookup_source_for_job(
+            conn,
+            provider=provider,
+            source_id=source_id,
+            source_url=source_url,
+        )
+        if not existing:
+            raise
+        return update_existing(existing)
     return source_ref
 
 
@@ -300,7 +356,7 @@ def create_job(
         source_url=source_url,
         input_path=input_path,
     )
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         source_ref = _upsert_source_for_job(
             conn,
             provider=provider,
@@ -343,7 +399,7 @@ def create_job(
 
 
 def get_job(db_path: Path, job_id: str) -> Optional[Job]:
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         row = conn.execute(
             f"SELECT {JOB_SELECT_COLUMNS} FROM jobs j JOIN sources s ON s.id = j.source_ref WHERE j.id = ?",
             (job_id,),
@@ -353,7 +409,7 @@ def get_job(db_path: Path, job_id: str) -> Optional[Job]:
 
 def set_job_status(db_path: Path, job_id: str, status: str, error: Optional[str] = None) -> None:
     now = _utc_now()
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         conn.execute(
             "UPDATE jobs SET status = ?, error = ?, updated_at = ? WHERE id = ?",
             (status, error, now, job_id),
@@ -363,7 +419,7 @@ def set_job_status(db_path: Path, job_id: str, status: str, error: Optional[str]
 
 def recover_stalled_processing_jobs(db_path: Path) -> int:
     now = _utc_now()
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         cur = conn.execute(
             "UPDATE jobs SET status = 'queued', progress = 0, error = NULL, updated_at = ? "
             "WHERE status = 'processing' AND error IS NULL",
@@ -374,7 +430,7 @@ def recover_stalled_processing_jobs(db_path: Path) -> int:
 
 
 def delete_job(db_path: Path, job_id: str) -> None:
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         row = conn.execute("SELECT source_ref FROM jobs WHERE id = ?", (job_id,)).fetchone()
         source_ref = row[0] if row else None
         conn.execute("DELETE FROM jobs WHERE id = ?", (job_id,))
@@ -389,32 +445,62 @@ def delete_job(db_path: Path, job_id: str) -> None:
         conn.commit()
 
 
-def claim_next_job(db_path: Path) -> Optional[Job]:
-    with sqlite3.connect(db_path) as conn:
+def _claim_next_job_once(db_path: Path) -> Optional[Job]:
+    with _connect(
+        db_path,
+        timeout_s=CLAIM_LOCK_BUSY_TIMEOUT_MS / 1000,
+        busy_timeout_ms=CLAIM_LOCK_BUSY_TIMEOUT_MS,
+    ) as conn:
         conn.isolation_level = None
-        conn.execute("BEGIN IMMEDIATE")
-        row = conn.execute(
-            "SELECT id FROM jobs WHERE status = 'queued' ORDER BY created_at, id LIMIT 1"
-        ).fetchone()
-        if not row:
+        transaction_started = False
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            transaction_started = True
+            row = conn.execute(
+                "SELECT id FROM jobs WHERE status = 'queued' ORDER BY created_at, id LIMIT 1"
+            ).fetchone()
+            if not row:
+                conn.execute("COMMIT")
+                transaction_started = False
+                return None
+            job_id = str(row[0])
+            now = _utc_now()
+            conn.execute(
+                "UPDATE jobs SET status = 'processing', progress = 0, updated_at = ? WHERE id = ?",
+                (now, job_id),
+            )
+            job_row = conn.execute(
+                f"SELECT {JOB_SELECT_COLUMNS} FROM jobs j JOIN sources s ON s.id = j.source_ref WHERE j.id = ?",
+                (job_id,),
+            ).fetchone()
             conn.execute("COMMIT")
-            return None
-        job_id = str(row[0])
-        now = _utc_now()
-        conn.execute(
-            "UPDATE jobs SET status = 'processing', progress = 0, updated_at = ? WHERE id = ?",
-            (now, job_id),
-        )
-        job_row = conn.execute(
-            f"SELECT {JOB_SELECT_COLUMNS} FROM jobs j JOIN sources s ON s.id = j.source_ref WHERE j.id = ?",
-            (job_id,),
-        ).fetchone()
-        conn.execute("COMMIT")
+            transaction_started = False
+        except Exception:
+            if transaction_started:
+                try:
+                    conn.execute("ROLLBACK")
+                except sqlite3.Error:
+                    pass
+            raise
     return _job_from_row(job_row)
 
 
+def claim_next_job(db_path: Path) -> Optional[Job]:
+    for attempt in range(CLAIM_LOCK_RETRY_COUNT):
+        try:
+            return _claim_next_job_once(db_path)
+        except sqlite3.OperationalError as exc:
+            if not _is_sqlite_lock_error(exc):
+                raise
+            if attempt >= CLAIM_LOCK_RETRY_COUNT - 1:
+                logger.warning("Could not claim a queued job because SQLite remained locked: %s", exc)
+                return None
+            _sleep_for_claim_retry(attempt)
+    return None
+
+
 def count_queued_jobs_ahead(db_path: Path, job_id: str, created_at: str) -> int:
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         row = conn.execute(
             """
             SELECT COUNT(*)
@@ -433,7 +519,7 @@ def count_queued_jobs_ahead(db_path: Path, job_id: str, created_at: str) -> int:
 
 
 def get_job_by_source(db_path: Path, source_provider: str, source_id: str) -> Optional[Job]:
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         row = conn.execute(
             f"SELECT {JOB_SELECT_COLUMNS} FROM jobs j "
             "JOIN sources s ON s.id = j.source_ref "
@@ -445,7 +531,7 @@ def get_job_by_source(db_path: Path, source_provider: str, source_id: str) -> Op
 
 
 def get_job_by_source_url(db_path: Path, source_url: str) -> Optional[Job]:
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         row = conn.execute(
             f"SELECT {JOB_SELECT_COLUMNS} FROM jobs j "
             "JOIN sources s ON s.id = j.source_ref "
@@ -457,7 +543,7 @@ def get_job_by_source_url(db_path: Path, source_url: str) -> Optional[Job]:
 
 
 def get_job_by_track(db_path: Path, title: str, artist: str) -> Optional[Job]:
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         row = conn.execute(
             f"SELECT {JOB_SELECT_COLUMNS} FROM jobs j "
             "JOIN sources s ON s.id = j.source_ref "
@@ -470,10 +556,9 @@ def get_job_by_track(db_path: Path, title: str, artist: str) -> Optional[Job]:
 
 def increment_job_plays(db_path: Path, job_id: str) -> Optional[int]:
     now = _utc_now()
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         row = conn.execute("SELECT source_ref FROM jobs WHERE id = ?", (job_id,)).fetchone()
         if not row:
-            conn.commit()
             return None
         source_ref = row[0]
         conn.execute(
@@ -498,10 +583,9 @@ def increment_job_plays(db_path: Path, job_id: str) -> Optional[int]:
 def set_job_play_count(db_path: Path, job_id: str, play_count: int) -> Optional[int]:
     now = _utc_now()
     clamped = max(0, int(play_count))
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         row = conn.execute("SELECT source_ref FROM jobs WHERE id = ?", (job_id,)).fetchone()
         if not row:
-            conn.commit()
             return None
         source_ref = row[0]
         conn.execute(
@@ -525,7 +609,7 @@ def set_job_play_count(db_path: Path, job_id: str, play_count: int) -> Optional[
 
 def set_job_progress(db_path: Path, job_id: str, progress: int) -> None:
     clamped = _clamp_progress(progress)
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         conn.execute(
             "UPDATE jobs SET progress = ?, updated_at = ? WHERE id = ?",
             (clamped, _utc_now(), job_id),
@@ -534,7 +618,7 @@ def set_job_progress(db_path: Path, job_id: str, progress: int) -> None:
 
 
 def update_job_input_path(db_path: Path, job_id: str, input_path: str) -> None:
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         conn.execute(
             "UPDATE jobs SET input_path = ?, updated_at = ? WHERE id = ?",
             (input_path, _utc_now(), job_id),
@@ -545,10 +629,9 @@ def update_job_input_path(db_path: Path, job_id: str, input_path: str) -> None:
 def update_job_track_metadata(
     db_path: Path, job_id: str, track_title: Optional[str], track_artist: Optional[str]
 ) -> None:
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         row = conn.execute("SELECT source_ref FROM jobs WHERE id = ?", (job_id,)).fetchone()
         if not row:
-            conn.commit()
             return
         source_ref = row[0]
         conn.execute(
@@ -586,7 +669,7 @@ def get_top_tracks(
     if touched_within_days is not None:
         cutoff = (datetime.now(timezone.utc) - timedelta(days=touched_within_days)).isoformat()
 
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         excluded_refs: list[str] = []
         if exclude_top_n is not None and exclude_top_n > 0:
             excluded_refs = _exclude_top_source_refs(conn, exclude_top_n)
@@ -662,7 +745,7 @@ def get_top_tracks(
 
 def get_recent_tracks(db_path: Path, limit: int = 10) -> list[dict]:
     activity_expr = "COALESCE(s.updated_at, s.created_at)"
-    with sqlite3.connect(db_path) as conn:
+    with _connect(db_path) as conn:
         rows = conn.execute(
             """
             SELECT

--- a/api/api/db.py
+++ b/api/api/db.py
@@ -19,10 +19,8 @@ logger = logging.getLogger("foreverjukebox.api.db")
 
 SQLITE_CONNECT_TIMEOUT_S = 30.0
 SQLITE_BUSY_TIMEOUT_MS = 30_000
-CLAIM_LOCK_BUSY_TIMEOUT_MS = 250
-CLAIM_LOCK_RETRY_COUNT = 5
-CLAIM_LOCK_RETRY_BASE_S = 0.05
-CLAIM_LOCK_RETRY_MAX_S = 0.75
+CLAIM_BUSY_TIMEOUT_MS = 250
+CLAIM_RETRY_DELAYS_S = (0.05, 0.1, 0.2, 0.4)
 
 
 @dataclass
@@ -123,11 +121,6 @@ def _is_sqlite_lock_error(exc: BaseException) -> bool:
         return False
     message = str(exc).lower()
     return "database is locked" in message or "database table is locked" in message
-
-
-def _sleep_for_claim_retry(attempt: int) -> None:
-    delay = min(CLAIM_LOCK_RETRY_MAX_S, CLAIM_LOCK_RETRY_BASE_S * (2**attempt))
-    time.sleep(delay + random.uniform(0.0, CLAIM_LOCK_RETRY_BASE_S))
 
 
 def _provider_for_url(source_url: str | None) -> str | None:
@@ -448,8 +441,8 @@ def delete_job(db_path: Path, job_id: str) -> None:
 def _claim_next_job_once(db_path: Path) -> Optional[Job]:
     with _connect(
         db_path,
-        timeout_s=CLAIM_LOCK_BUSY_TIMEOUT_MS / 1000,
-        busy_timeout_ms=CLAIM_LOCK_BUSY_TIMEOUT_MS,
+        timeout_s=CLAIM_BUSY_TIMEOUT_MS / 1000,
+        busy_timeout_ms=CLAIM_BUSY_TIMEOUT_MS,
     ) as conn:
         conn.isolation_level = None
         transaction_started = False
@@ -486,16 +479,17 @@ def _claim_next_job_once(db_path: Path) -> Optional[Job]:
 
 
 def claim_next_job(db_path: Path) -> Optional[Job]:
-    for attempt in range(CLAIM_LOCK_RETRY_COUNT):
+    retry_delays = (*CLAIM_RETRY_DELAYS_S, None)
+    for delay in retry_delays:
         try:
             return _claim_next_job_once(db_path)
         except sqlite3.OperationalError as exc:
             if not _is_sqlite_lock_error(exc):
                 raise
-            if attempt >= CLAIM_LOCK_RETRY_COUNT - 1:
+            if delay is None:
                 logger.warning("Could not claim a queued job because SQLite remained locked: %s", exc)
                 return None
-            _sleep_for_claim_retry(attempt)
+            time.sleep(delay + random.uniform(0.0, delay))
     return None
 
 

--- a/api/tests/test_job_recovery.py
+++ b/api/tests/test_job_recovery.py
@@ -83,9 +83,9 @@ class JobRecoveryTests(unittest.TestCase):
             lock_conn.execute("BEGIN IMMEDIATE")
             try:
                 with (
-                    patch.object(db_module, "CLAIM_LOCK_BUSY_TIMEOUT_MS", 10),
-                    patch.object(db_module, "CLAIM_LOCK_RETRY_COUNT", 2),
-                    patch.object(db_module, "_sleep_for_claim_retry"),
+                    patch.object(db_module, "CLAIM_BUSY_TIMEOUT_MS", 10),
+                    patch.object(db_module, "CLAIM_RETRY_DELAYS_S", (0.01,)),
+                    patch.object(db_module.time, "sleep"),
                 ):
                     self.assertIsNone(claim_next_job(db_path))
             finally:

--- a/api/tests/test_job_recovery.py
+++ b/api/tests/test_job_recovery.py
@@ -5,6 +5,7 @@ import os
 import sqlite3
 import tempfile
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -12,7 +13,8 @@ from unittest.mock import patch
 
 from fastapi import BackgroundTasks
 
-from api.db import create_job, get_job, init_db, recover_stalled_processing_jobs, set_job_status
+from api import db as db_module
+from api.db import claim_next_job, create_job, get_job, init_db, recover_stalled_processing_jobs, set_job_status
 from api.models import AnalysisUrlRequest
 from api.routes import jobs
 from api.routes.jobs import _create_source_job, _should_attempt_auto_repair
@@ -21,6 +23,146 @@ from worker import worker as worker_module
 
 
 class JobRecoveryTests(unittest.TestCase):
+    def test_init_db_enables_wal_busy_timeout_and_foreign_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "jobs.db"
+
+            init_db(db_path)
+
+            with db_module._connect(db_path) as conn:
+                journal_mode = conn.execute("PRAGMA journal_mode").fetchone()
+                busy_timeout = conn.execute("PRAGMA busy_timeout").fetchone()
+                foreign_keys = conn.execute("PRAGMA foreign_keys").fetchone()
+                with self.assertRaises(sqlite3.IntegrityError):
+                    conn.execute(
+                        """
+                        INSERT INTO jobs (
+                            id, source_ref, status, input_path, output_path,
+                            error, progress, created_at, updated_at
+                        )
+                        VALUES ('orphan', 'missing-source', 'queued', '', '', NULL, 0, 'now', 'now')
+                        """
+                    )
+
+            self.assertEqual(journal_mode[0].lower(), "wal")
+            self.assertGreaterEqual(int(busy_timeout[0]), db_module.SQLITE_BUSY_TIMEOUT_MS)
+            self.assertEqual(int(foreign_keys[0]), 1)
+
+    def test_concurrent_claims_are_unique_with_six_workers(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "jobs.db"
+            init_db(db_path)
+            for index in range(6):
+                create_job(
+                    db_path,
+                    f"job-{index}",
+                    f"audio/job-{index}.mp3",
+                    f"analysis/job-{index}.json",
+                    "queued",
+                )
+
+            def claim_id() -> str | None:
+                job = claim_next_job(db_path)
+                return job.id if job else None
+
+            with ThreadPoolExecutor(max_workers=6) as executor:
+                claimed_ids = list(executor.map(lambda _: claim_id(), range(6)))
+
+            self.assertEqual(len(set(claimed_ids)), 6)
+            self.assertNotIn(None, claimed_ids)
+            for job_id in claimed_ids:
+                self.assertEqual(get_job(db_path, str(job_id)).status, "processing")
+
+    def test_claim_next_job_returns_none_when_database_stays_locked(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "jobs.db"
+            init_db(db_path)
+            create_job(db_path, "locked-job", "audio/locked.mp3", "analysis/locked.json", "queued")
+            lock_conn = sqlite3.connect(db_path, timeout=0.01)
+            lock_conn.isolation_level = None
+            lock_conn.execute("BEGIN IMMEDIATE")
+            try:
+                with (
+                    patch.object(db_module, "CLAIM_LOCK_BUSY_TIMEOUT_MS", 10),
+                    patch.object(db_module, "CLAIM_LOCK_RETRY_COUNT", 2),
+                    patch.object(db_module, "_sleep_for_claim_retry"),
+                ):
+                    self.assertIsNone(claim_next_job(db_path))
+            finally:
+                lock_conn.execute("ROLLBACK")
+                lock_conn.close()
+
+            self.assertEqual(get_job(db_path, "locked-job").status, "queued")
+
+    def test_claim_next_job_rolls_back_after_mid_transaction_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "jobs.db"
+            init_db(db_path)
+            create_job(db_path, "rollback-job", "audio/rollback.mp3", "analysis/rollback.json", "queued")
+
+            with patch.object(db_module, "_utc_now", side_effect=RuntimeError("forced failure")):
+                with self.assertRaisesRegex(RuntimeError, "forced failure"):
+                    claim_next_job(db_path)
+
+            claimed = claim_next_job(db_path)
+
+            self.assertIsNotNone(claimed)
+            self.assertEqual(claimed.id, "rollback-job")
+            self.assertEqual(get_job(db_path, "rollback-job").status, "processing")
+
+    def test_create_job_recovers_when_source_is_inserted_between_lookup_and_insert(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "jobs.db"
+            init_db(db_path)
+            create_job(
+                db_path,
+                "existing-job",
+                "audio/existing.mp3",
+                "analysis/existing.json",
+                "queued",
+                track_title="Original Title",
+                track_artist="Original Artist",
+                source_id="yt-race",
+                source_provider="youtube",
+                source_url="https://www.youtube.com/watch?v=yt-race",
+            )
+            original_lookup = db_module._lookup_source_for_job
+            lookup_calls = 0
+
+            def simulate_stale_first_lookup(conn, *, provider, source_id, source_url):
+                nonlocal lookup_calls
+                lookup_calls += 1
+                if lookup_calls == 1:
+                    return None
+                return original_lookup(
+                    conn,
+                    provider=provider,
+                    source_id=source_id,
+                    source_url=source_url,
+                )
+
+            with patch.object(db_module, "_lookup_source_for_job", side_effect=simulate_stale_first_lookup):
+                create_job(
+                    db_path,
+                    "new-job",
+                    "audio/new.mp3",
+                    "analysis/new.json",
+                    "queued",
+                    track_title="New Title",
+                    track_artist="New Artist",
+                    source_id="yt-race",
+                    source_provider="youtube",
+                    source_url="https://www.youtube.com/watch?v=yt-race",
+                )
+
+            self.assertGreaterEqual(lookup_calls, 2)
+            with db_module._connect(db_path) as conn:
+                source_count = conn.execute("SELECT COUNT(*) FROM sources").fetchone()
+                job_count = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()
+
+            self.assertEqual(source_count[0], 1)
+            self.assertEqual(job_count[0], 2)
+
     def test_recover_stalled_processing_jobs_leaves_failed_and_errored_jobs_alone(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             db_path = Path(temp_dir) / "jobs.db"

--- a/api/worker/worker.py
+++ b/api/worker/worker.py
@@ -251,6 +251,7 @@ def run_worker_loop() -> None:
             elapsed_ms=_completion_elapsed_ms(job),
         )
 
+
 def main() -> None:
     init_db(DB_PATH)
     STORAGE_ROOT.mkdir(parents=True, exist_ok=True)

--- a/api/worker/worker.py
+++ b/api/worker/worker.py
@@ -251,7 +251,6 @@ def run_worker_loop() -> None:
             elapsed_ms=_completion_elapsed_ms(job),
         )
 
-
 def main() -> None:
     init_db(DB_PATH)
     STORAGE_ROOT.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
- Add shared SQLite connection setup for `jobs.db` with busy timeout, WAL mode, and foreign key enforcement.
- Make worker job claiming resilient to SQLite lock contention with bounded retry/backoff and explicit transaction rollback.
- Keep queue claiming atomic with `BEGIN IMMEDIATE` while avoiding worker crashes when the DB is temporarily locked.
- Handle concurrent source creation races by recovering from unique-index conflicts during source upsert.
- Remove redundant worker-side lock handling and redundant commits on read-only miss paths.
- Document SQLite deployment boundaries for modest `WORKER_COUNT` concurrency, single-instance storage, and sidecar DB files.
- Add tests for six concurrent claims, persistent lock contention, rollback cleanup, WAL/busy timeout/foreign key setup, and concurrent source insert recovery.