### PR TITLE
storage cleanup job

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -217,6 +217,26 @@ Within 30 minutes of creation/completion, the admin header is not required:
 curl -X DELETE "/api/jobs/<id>"
 ```
 
+Preview manual storage cleanup for cold, low-play tracks (admin):
+
+```bash
+curl -X POST "/api/admin/storage-cleanup" \
+  -H "Content-Type: application/json" \
+  -H "X-Admin-Key: $ADMIN_KEY" \
+  -d '{}'
+```
+
+The cleanup policy is server-side: completed jobs with `play_count < 3` and
+source activity older than 90 days. Dry-run is the default. To execute the
+cleanup, set `dry_run` to `false` and include the explicit confirmation:
+
+```bash
+curl -X POST "/api/admin/storage-cleanup" \
+  -H "Content-Type: application/json" \
+  -H "X-Admin-Key: $ADMIN_KEY" \
+  -d '{"dry_run":false,"confirm":"delete"}'
+```
+
 ## Storage
 
 Jobs and analysis outputs are stored under `storage/` in this repo:

--- a/api/api/admin_auth.py
+++ b/api/api/admin_auth.py
@@ -1,0 +1,23 @@
+"""Shared admin authentication helpers."""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import HTTPException
+
+
+ADMIN_KEY_HEADER = "X-Admin-Key"
+
+
+def admin_key_matches(provided_key: str | None) -> bool:
+    expected_key = os.environ.get("ADMIN_KEY")
+    return bool(expected_key and provided_key == expected_key)
+
+
+def require_admin_key(provided_key: str | None) -> None:
+    expected_key = os.environ.get("ADMIN_KEY")
+    if not expected_key:
+        raise HTTPException(status_code=403, detail="ADMIN_KEY is not configured")
+    if not provided_key or provided_key != expected_key:
+        raise HTTPException(status_code=403, detail="Invalid admin key")

--- a/api/api/main.py
+++ b/api/api/main.py
@@ -19,12 +19,14 @@ from .paths import DB_PATH, FAVORITES_DB_PATH, STORAGE_ROOT, WEB_DIST
 load_dotenv()
 
 from .routes.config import router as config_router
+from .routes.admin import router as admin_router
 from .routes.favorites import router as favorites_router
 from .routes.jobs import router as jobs_router
 from .routes.media import router as media_router
 from .routes.search import router as search_router
 
 app = FastAPI(title="The Forever Jukebox Analysis API")
+app.include_router(admin_router)
 app.include_router(config_router)
 app.include_router(favorites_router)
 app.include_router(jobs_router)

--- a/api/api/models.py
+++ b/api/api/models.py
@@ -78,6 +78,41 @@ class PlayCountUpdate(BaseModel):
     play_count: int
 
 
+class StorageCleanupRequest(BaseModel):
+    dry_run: bool = True
+    confirm: str | None = None
+
+
+class StorageCleanupSampleItem(BaseModel):
+    job_id: str
+    provider: str
+    source_id: str | None = None
+    source_url: str | None = None
+    title: str | None = None
+    artist: str | None = None
+    play_count: int
+    updated_at: str
+    bytes: int
+
+
+class StorageCleanupError(BaseModel):
+    job_id: str
+    error: str
+
+
+class StorageCleanupResponse(BaseModel):
+    dry_run: bool
+    days: int
+    play_count_below: int
+    candidate_jobs: int
+    candidate_bytes: int
+    sample: list[StorageCleanupSampleItem]
+    deleted_jobs: int
+    deleted_bytes: int
+    failed_jobs: int
+    errors: list[StorageCleanupError]
+
+
 class AnalysisStartResponse(BaseModel):
     id: str
     status: Literal["queued", "downloading"]

--- a/api/api/routes/admin.py
+++ b/api/api/routes/admin.py
@@ -1,0 +1,39 @@
+"""Admin-only maintenance routes."""
+
+from __future__ import annotations
+
+from threading import Lock
+
+from fastapi import APIRouter, Header, HTTPException
+
+from ..admin_auth import ADMIN_KEY_HEADER, require_admin_key
+from ..models import StorageCleanupRequest, StorageCleanupResponse
+from ..paths import DB_PATH, STORAGE_ROOT
+from ..storage_cleanup import build_cleanup_preview, execute_cleanup
+
+router = APIRouter()
+_storage_cleanup_lock = Lock()
+
+
+@router.post("/api/admin/storage-cleanup")
+def run_storage_cleanup(
+    payload: StorageCleanupRequest,
+    admin_key: str | None = Header(None, alias=ADMIN_KEY_HEADER),
+) -> StorageCleanupResponse:
+    require_admin_key(admin_key)
+    if not _storage_cleanup_lock.acquire(blocking=False):
+        raise HTTPException(status_code=409, detail="Storage cleanup is already running")
+    try:
+        if payload.dry_run:
+            return build_cleanup_preview(
+                DB_PATH,
+                STORAGE_ROOT,
+            )
+        if payload.confirm != "delete":
+            raise HTTPException(status_code=400, detail='confirm must be "delete" when dry_run is false')
+        return execute_cleanup(
+            DB_PATH,
+            STORAGE_ROOT,
+        )
+    finally:
+        _storage_cleanup_lock.release()

--- a/api/api/routes/jobs.py
+++ b/api/api/routes/jobs.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -12,6 +11,7 @@ from urllib.parse import parse_qs, urlsplit
 from fastapi import APIRouter, BackgroundTasks, File, Header, HTTPException, Query, UploadFile
 from fastapi.responses import JSONResponse
 
+from ..admin_auth import ADMIN_KEY_HEADER, admin_key_matches, require_admin_key
 from ..db import (
     count_queued_jobs_ahead,
     create_job,
@@ -69,7 +69,6 @@ from .jobs_runtime import (
 
 router = APIRouter()
 
-ADMIN_KEY_HEADER = "X-Admin-Key"
 TRENDING_DEFAULT_DAYS = 5
 TRENDING_DEFAULT_EXCLUDE_TOP_N = 25
 TRENDING_DEFAULT_LIMIT = 25
@@ -81,19 +80,6 @@ SUPPORTED_SOURCE_PROVIDERS = {"youtube", "soundcloud", "bandcamp", "upload"}
 
 def _allow_user_url() -> bool:
     return env_flag("ALLOW_USER_URL")
-
-
-def _admin_key_matches(provided_key: str | None) -> bool:
-    expected_key = os.environ.get("ADMIN_KEY")
-    return bool(expected_key and provided_key == expected_key)
-
-
-def _require_admin_key(provided_key: str | None) -> None:
-    expected_key = os.environ.get("ADMIN_KEY")
-    if not expected_key:
-        raise HTTPException(status_code=403, detail="ADMIN_KEY is not configured")
-    if not provided_key or provided_key != expected_key:
-        raise HTTPException(status_code=403, detail="Invalid admin key")
 
 
 def _source_url_for_job(job) -> str | None:
@@ -622,7 +608,7 @@ def set_play_count(
     payload: PlayCountUpdate,
     admin_key: str | None = Header(None, alias=ADMIN_KEY_HEADER),
 ) -> JSONResponse:
-    _require_admin_key(admin_key)
+    require_admin_key(admin_key)
     play_count = set_job_play_count(DB_PATH, job_id, payload.play_count)
     if play_count is None:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -734,7 +720,7 @@ def delete_job_by_id(
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
 
-    is_admin_delete = _admin_key_matches(admin_key)
+    is_admin_delete = admin_key_matches(admin_key)
     if not is_admin_delete:
         created_at = parse_timestamp(job.created_at)
         completion_time = None

--- a/api/api/routes/jobs_runtime.py
+++ b/api/api/routes/jobs_runtime.py
@@ -510,20 +510,20 @@ def cleanup_failure(
     logger.info("Job %s failed: %s", job_id, message)
 
 
-def delete_job_artifacts(job_id: str, job) -> None:
+def delete_job_artifacts(job_id: str, job, storage_root: Path = STORAGE_ROOT) -> None:
     paths: list[Path] = []
     if job and job.input_path:
-        paths.append(abs_storage_path(STORAGE_ROOT, job.input_path))
+        paths.append(abs_storage_path(storage_root, job.input_path))
     if job and job.output_path:
-        paths.append(abs_storage_path(STORAGE_ROOT, job.output_path))
-    paths.append(STORAGE_ROOT / "logs" / f"{job_id}.log")
+        paths.append(abs_storage_path(storage_root, job.output_path))
+    paths.append(storage_root / "logs" / f"{job_id}.log")
     for path in paths:
         if path.is_file():
             path.unlink()
-    for candidate in (STORAGE_ROOT / "audio").glob(f"{job_id}.*"):
+    for candidate in (storage_root / "audio").glob(f"{job_id}.*"):
         if candidate.is_file():
             candidate.unlink()
-    for candidate in (STORAGE_ROOT / "analysis").glob(f"{job_id}.*"):
+    for candidate in (storage_root / "analysis").glob(f"{job_id}.*"):
         if candidate.is_file():
             candidate.unlink()
 

--- a/api/api/storage_cleanup.py
+++ b/api/api/storage_cleanup.py
@@ -1,0 +1,218 @@
+"""Manual storage cleanup for cold completed jobs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .db import _connect, delete_job
+from .models import StorageCleanupError, StorageCleanupResponse, StorageCleanupSampleItem
+from .routes.jobs_runtime import delete_job_artifacts
+from .utils import abs_storage_path
+
+
+CLEANUP_POLICY_DAYS = 90
+CLEANUP_POLICY_PLAY_COUNT_BELOW = 3
+SAMPLE_SIZE = 10
+
+
+@dataclass(frozen=True)
+class CleanupCandidate:
+    job_id: str
+    input_path: str
+    output_path: str
+    provider: str
+    source_id: str | None
+    source_url: str | None
+    title: str | None
+    artist: str | None
+    play_count: int
+    updated_at: str
+
+
+def _cutoff_arg(days: int) -> str:
+    return f"-{max(1, int(days))} days"
+
+
+def _candidate_from_row(row: tuple) -> CleanupCandidate:
+    return CleanupCandidate(
+        job_id=str(row[0]),
+        input_path=str(row[1] or ""),
+        output_path=str(row[2] or ""),
+        provider=str(row[3] or ""),
+        source_id=str(row[4]) if row[4] is not None else None,
+        source_url=str(row[5]) if row[5] is not None else None,
+        title=str(row[6]) if row[6] is not None else None,
+        artist=str(row[7]) if row[7] is not None else None,
+        play_count=int(row[8] or 0),
+        updated_at=str(row[9] or ""),
+    )
+
+
+def find_cleanup_candidates(db_path: Path) -> list[CleanupCandidate]:
+    with _connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT
+              j.id,
+              j.input_path,
+              j.output_path,
+              s.provider,
+              s.source_id,
+              s.source_url,
+              s.track_title,
+              s.track_artist,
+              s.play_count,
+              s.updated_at
+            FROM jobs j
+            JOIN sources s ON s.id = j.source_ref
+            WHERE j.status = 'complete'
+              AND s.play_count < ?
+              AND julianday(s.updated_at) < julianday('now', ?)
+            ORDER BY s.updated_at ASC, j.id ASC
+            """,
+            (CLEANUP_POLICY_PLAY_COUNT_BELOW, _cutoff_arg(CLEANUP_POLICY_DAYS)),
+        ).fetchall()
+    return [_candidate_from_row(row) for row in rows]
+
+
+def find_cleanup_candidate_by_id(
+    db_path: Path,
+    job_id: str,
+) -> CleanupCandidate | None:
+    with _connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT
+              j.id,
+              j.input_path,
+              j.output_path,
+              s.provider,
+              s.source_id,
+              s.source_url,
+              s.track_title,
+              s.track_artist,
+              s.play_count,
+              s.updated_at
+            FROM jobs j
+            JOIN sources s ON s.id = j.source_ref
+            WHERE j.id = ?
+              AND j.status = 'complete'
+              AND s.play_count < ?
+              AND julianday(s.updated_at) < julianday('now', ?)
+            """,
+            (job_id, CLEANUP_POLICY_PLAY_COUNT_BELOW, _cutoff_arg(CLEANUP_POLICY_DAYS)),
+        ).fetchone()
+    return _candidate_from_row(row) if row else None
+
+
+def artifact_paths(storage_root: Path, candidate: CleanupCandidate) -> list[Path]:
+    paths: list[Path] = []
+    if candidate.input_path:
+        paths.append(abs_storage_path(storage_root, candidate.input_path))
+    if candidate.output_path:
+        paths.append(abs_storage_path(storage_root, candidate.output_path))
+    paths.append(storage_root / "logs" / f"{candidate.job_id}.log")
+    paths.extend((storage_root / "audio").glob(f"{candidate.job_id}.*"))
+    paths.extend((storage_root / "analysis").glob(f"{candidate.job_id}.*"))
+
+    unique_paths: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        resolved = path.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique_paths.append(path)
+    return unique_paths
+
+
+def candidate_bytes(storage_root: Path, candidate: CleanupCandidate) -> int:
+    total = 0
+    for path in artifact_paths(storage_root, candidate):
+        if not path.is_file():
+            continue
+        try:
+            total += path.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def build_cleanup_preview(db_path: Path, storage_root: Path) -> StorageCleanupResponse:
+    candidates = find_cleanup_candidates(db_path)
+    bytes_by_job = {
+        candidate.job_id: candidate_bytes(storage_root, candidate)
+        for candidate in candidates
+    }
+    sample = [
+        StorageCleanupSampleItem(
+            job_id=candidate.job_id,
+            provider=candidate.provider,
+            source_id=candidate.source_id,
+            source_url=candidate.source_url,
+            title=candidate.title,
+            artist=candidate.artist,
+            play_count=candidate.play_count,
+            updated_at=candidate.updated_at,
+            bytes=bytes_by_job[candidate.job_id],
+        )
+        for candidate in candidates[:SAMPLE_SIZE]
+    ]
+    return StorageCleanupResponse(
+        dry_run=True,
+        days=CLEANUP_POLICY_DAYS,
+        play_count_below=CLEANUP_POLICY_PLAY_COUNT_BELOW,
+        candidate_jobs=len(candidates),
+        candidate_bytes=sum(bytes_by_job.values()),
+        sample=sample,
+        deleted_jobs=0,
+        deleted_bytes=0,
+        failed_jobs=0,
+        errors=[],
+    )
+
+
+def execute_cleanup(db_path: Path, storage_root: Path) -> StorageCleanupResponse:
+    preview = build_cleanup_preview(db_path, storage_root)
+    candidates = find_cleanup_candidates(db_path)
+    deleted_jobs = 0
+    deleted_bytes = 0
+    errors: list[StorageCleanupError] = []
+
+    for candidate in candidates:
+        eligible = find_cleanup_candidate_by_id(
+            db_path,
+            candidate.job_id,
+        )
+        if not eligible:
+            continue
+
+        bytes_to_delete = candidate_bytes(storage_root, eligible)
+        try:
+            delete_job_artifacts(eligible.job_id, eligible, storage_root)
+            delete_job(db_path, eligible.job_id)
+        except Exception as exc:  # noqa: BLE001 - cleanup should report and continue.
+            errors.append(
+                StorageCleanupError(
+                    job_id=eligible.job_id,
+                    error=str(exc) or exc.__class__.__name__,
+                )
+            )
+            continue
+
+        deleted_jobs += 1
+        deleted_bytes += bytes_to_delete
+
+    return StorageCleanupResponse(
+        dry_run=False,
+        days=CLEANUP_POLICY_DAYS,
+        play_count_below=CLEANUP_POLICY_PLAY_COUNT_BELOW,
+        candidate_jobs=preview.candidate_jobs,
+        candidate_bytes=preview.candidate_bytes,
+        sample=[],
+        deleted_jobs=deleted_jobs,
+        deleted_bytes=deleted_bytes,
+        failed_jobs=len(errors),
+        errors=errors,
+    )

--- a/api/tests/test_storage_cleanup.py
+++ b/api/tests/test_storage_cleanup.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from api import db as db_module
+from api.db import create_job, get_job, init_db
+from api.models import StorageCleanupRequest
+from api.routes import admin as admin_routes
+from api.storage_cleanup import build_cleanup_preview, execute_cleanup
+
+
+OLD_UPDATED_AT = "2000-01-01T00:00:00.000000+00:00"
+RECENT_UPDATED_AT = "2999-01-01T00:00:00.000000+00:00"
+
+
+def _write_file(path: Path, size: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x" * size)
+
+
+def _set_source_activity(db_path: Path, job_id: str, *, play_count: int, updated_at: str) -> None:
+    with db_module._connect(db_path) as conn:
+        conn.execute(
+            """
+            UPDATE sources
+            SET play_count = ?, updated_at = ?
+            WHERE id = (SELECT source_ref FROM jobs WHERE id = ?)
+            """,
+            (play_count, updated_at, job_id),
+        )
+        conn.commit()
+
+
+def _job_count(db_path: Path) -> int:
+    with db_module._connect(db_path) as conn:
+        row = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()
+    return int(row[0])
+
+
+def _source_count(db_path: Path) -> int:
+    with db_module._connect(db_path) as conn:
+        row = conn.execute("SELECT COUNT(*) FROM sources").fetchone()
+    return int(row[0])
+
+
+def _make_job(
+    db_path: Path,
+    storage_root: Path,
+    job_id: str,
+    *,
+    status: str = "complete",
+    play_count: int = 1,
+    updated_at: str = OLD_UPDATED_AT,
+    title: str | None = None,
+    audio_bytes: int = 3,
+    analysis_bytes: int = 5,
+    log_bytes: int = 7,
+    write_files: bool = True,
+) -> None:
+    input_path = f"audio/{job_id}.m4a"
+    output_path = f"analysis/{job_id}.json"
+    create_job(
+        db_path,
+        job_id,
+        input_path,
+        output_path,
+        status=status,
+        track_title=title or f"Track {job_id}",
+        track_artist="Artist",
+        source_id=f"source-{job_id}",
+        source_provider="youtube",
+        source_url=f"https://www.youtube.com/watch?v=source-{job_id}",
+    )
+    _set_source_activity(db_path, job_id, play_count=play_count, updated_at=updated_at)
+    if write_files:
+        _write_file(storage_root / input_path, audio_bytes)
+        _write_file(storage_root / output_path, analysis_bytes)
+        _write_file(storage_root / "logs" / f"{job_id}.log", log_bytes)
+
+
+class StorageCleanupTests(unittest.TestCase):
+    def test_post_dry_run_requires_valid_admin_key(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "jobs.db"
+            storage_root = Path(temp_dir) / "storage"
+            init_db(db_path)
+            payload = StorageCleanupRequest()
+            with (
+                patch.dict(os.environ, {"ADMIN_KEY": "secret"}, clear=True),
+                patch.object(admin_routes, "DB_PATH", db_path),
+                patch.object(admin_routes, "STORAGE_ROOT", storage_root),
+            ):
+                with self.assertRaises(HTTPException) as missing:
+                    admin_routes.run_storage_cleanup(payload, admin_key=None)
+                with self.assertRaises(HTTPException) as wrong:
+                    admin_routes.run_storage_cleanup(payload, admin_key="wrong")
+
+                response = admin_routes.run_storage_cleanup(payload, admin_key="secret")
+
+        self.assertEqual(missing.exception.status_code, 403)
+        self.assertEqual(wrong.exception.status_code, 403)
+        self.assertTrue(response.dry_run)
+        self.assertEqual(response.candidate_jobs, 0)
+
+    def test_preview_uses_defaults_and_does_not_delete(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "jobs.db"
+            storage_root = Path(temp_dir) / "storage"
+            init_db(db_path)
+            _make_job(db_path, storage_root, "old-job")
+
+            response = build_cleanup_preview(db_path, storage_root)
+
+            self.assertTrue(response.dry_run)
+            self.assertEqual(response.days, 90)
+            self.assertEqual(response.play_count_below, 3)
+            self.assertEqual(response.candidate_jobs, 1)
+            self.assertEqual(response.candidate_bytes, 15)
+            self.assertEqual(_job_count(db_path), 1)
+            self.assertTrue((storage_root / "audio" / "old-job.m4a").exists())
+
+    def test_preview_includes_at_most_ten_oldest_samples(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "jobs.db"
+            storage_root = Path(temp_dir) / "storage"
+            init_db(db_path)
+            for index in range(12):
+                updated_at = f"2000-01-{index + 1:02d}T00:00:00.000000+00:00"
+                _make_job(
+                    db_path,
+                    storage_root,
+                    f"job-{index:02d}",
+                    updated_at=updated_at,
+                    title=f"Track {index:02d}",
+                )
+
+            response = build_cleanup_preview(db_path, storage_root)
+
+        self.assertEqual(response.candidate_jobs, 12)
+        self.assertEqual(len(response.sample), 10)
+        self.assertEqual([item.job_id for item in response.sample], [f"job-{index:02d}" for index in range(10)])
+
+    def test_execute_rejects_missing_or_wrong_confirmation(self) -> None:
+        with patch.dict(os.environ, {"ADMIN_KEY": "secret"}, clear=True):
+            for confirm in (None, "yes"):
+                with self.subTest(confirm=confirm):
+                    with self.assertRaises(HTTPException) as raised:
+                        admin_routes.run_storage_cleanup(
+                            StorageCleanupRequest(dry_run=False, confirm=confirm),
+                            admin_key="secret",
+                        )
+
+                    self.assertEqual(raised.exception.status_code, 400)
+
+    def test_post_rejects_when_cleanup_is_already_running(self) -> None:
+        acquired = admin_routes._storage_cleanup_lock.acquire(blocking=False)
+        self.assertTrue(acquired)
+        try:
+            with patch.dict(os.environ, {"ADMIN_KEY": "secret"}, clear=True):
+                with self.assertRaises(HTTPException) as raised:
+                    admin_routes.run_storage_cleanup(
+                        StorageCleanupRequest(),
+                        admin_key="secret",
+                    )
+        finally:
+            admin_routes._storage_cleanup_lock.release()
+
+        self.assertEqual(raised.exception.status_code, 409)
+        self.assertEqual(raised.exception.detail, "Storage cleanup is already running")
+
+    def test_post_releases_running_guard_after_confirmation_error(self) -> None:
+        with patch.dict(os.environ, {"ADMIN_KEY": "secret"}, clear=True):
+            with self.assertRaises(HTTPException) as raised:
+                admin_routes.run_storage_cleanup(
+                    StorageCleanupRequest(dry_run=False),
+                    admin_key="secret",
+                )
+
+            response = admin_routes.run_storage_cleanup(
+                StorageCleanupRequest(),
+                admin_key="secret",
+            )
+
+        self.assertEqual(raised.exception.status_code, 400)
+        self.assertTrue(response.dry_run)
+
+    def test_execute_deletes_only_eligible_complete_jobs(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "jobs.db"
+            storage_root = Path(temp_dir) / "storage"
+            init_db(db_path)
+            _make_job(db_path, storage_root, "eligible")
+            _make_job(db_path, storage_root, "recent", updated_at=RECENT_UPDATED_AT)
+            _make_job(db_path, storage_root, "popular", play_count=3)
+            _make_job(db_path, storage_root, "queued", status="queued")
+
+            response = execute_cleanup(db_path, storage_root)
+
+            self.assertFalse(response.dry_run)
+            self.assertEqual(response.candidate_jobs, 1)
+            self.assertEqual(response.deleted_jobs, 1)
+            self.assertEqual(response.deleted_bytes, 15)
+            self.assertEqual(response.failed_jobs, 0)
+            self.assertIsNone(get_job(db_path, "eligible"))
+            self.assertIsNotNone(get_job(db_path, "recent"))
+            self.assertIsNotNone(get_job(db_path, "popular"))
+            self.assertIsNotNone(get_job(db_path, "queued"))
+            self.assertFalse((storage_root / "audio" / "eligible.m4a").exists())
+            self.assertFalse((storage_root / "analysis" / "eligible.json").exists())
+            self.assertFalse((storage_root / "logs" / "eligible.log").exists())
+            self.assertTrue((storage_root / "audio" / "recent.m4a").exists())
+            self.assertEqual(_job_count(db_path), 3)
+            self.assertEqual(_source_count(db_path), 3)
+
+    def test_missing_files_do_not_fail_deletion(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "jobs.db"
+            storage_root = Path(temp_dir) / "storage"
+            init_db(db_path)
+            _make_job(db_path, storage_root, "missing-files", write_files=False)
+
+            response = execute_cleanup(db_path, storage_root)
+
+            self.assertEqual(response.deleted_jobs, 1)
+            self.assertEqual(response.deleted_bytes, 0)
+            self.assertEqual(response.failed_jobs, 0)
+            self.assertIsNone(get_job(db_path, "missing-files"))
+
+    def test_unlink_failure_records_error_and_keeps_db_row(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "jobs.db"
+            storage_root = Path(temp_dir) / "storage"
+            init_db(db_path)
+            _make_job(db_path, storage_root, "fail")
+            original_unlink = Path.unlink
+
+            def fail_first_audio(path: Path, *args, **kwargs):
+                if path.name == "fail.m4a":
+                    raise OSError("cannot unlink")
+                return original_unlink(path, *args, **kwargs)
+
+            with patch.object(Path, "unlink", fail_first_audio):
+                response = execute_cleanup(db_path, storage_root)
+
+            self.assertEqual(response.deleted_jobs, 0)
+            self.assertEqual(response.failed_jobs, 1)
+            self.assertEqual(response.errors[0].job_id, "fail")
+            self.assertIn("cannot unlink", response.errors[0].error)
+            self.assertIsNotNone(get_job(db_path, "fail"))
+            self.assertTrue((storage_root / "audio" / "fail.m4a").exists())
+
+    def test_iso_timestamp_with_t_separator_is_compared_by_julianday(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "jobs.db"
+            storage_root = Path(temp_dir) / "storage"
+            init_db(db_path)
+            _make_job(db_path, storage_root, "old-iso", updated_at=OLD_UPDATED_AT)
+            _make_job(db_path, storage_root, "recent-iso", updated_at=RECENT_UPDATED_AT)
+
+            response = build_cleanup_preview(db_path, storage_root)
+
+        self.assertEqual(response.candidate_jobs, 1)
+        self.assertEqual(response.sample[0].job_id, "old-iso")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Adds admin-keyed API endpoint for manual storage cleanup for cold, low-play tracks.
- The cleanup is hardcoded to completed jobs with `play_count < 3` and source activity older than 90 days.
- Dry-run is the default mode, see documentation for usage.