### PR TITLE
Add local playlist support to the web app

### DIFF
--- a/pwa/src/app/routes/Listen.tsx
+++ b/pwa/src/app/routes/Listen.tsx
@@ -2114,11 +2114,13 @@ export function Listen({ isActive = true }: { isActive?: boolean }) {
               <div className="viz-info">
                 <div className="viz-title" id="viz-now-playing">{displayTitle}</div>
                 <div className="viz-meta">
-                  <span>Listen Time:</span>
-                  <span>{formatDuration(listenSeconds)}</span>
-                  <span className={`viz-divider ${playMode === "autocanonizer" ? "is-hidden" : ""}`}>·</span>
-                  <span className={playMode === "autocanonizer" ? "is-hidden" : ""}>Total Beats:</span>
-                  <span className={playMode === "autocanonizer" ? "is-hidden" : ""}>{beatsPlayed}</span>
+                  <span className="viz-meta-stats">
+                    <span>Listen Time:</span>
+                    <span>{formatDuration(listenSeconds)}</span>
+                    <span className={`viz-divider ${playMode === "autocanonizer" ? "is-hidden" : ""}`}>·</span>
+                    <span className={playMode === "autocanonizer" ? "is-hidden" : ""}>Total Beats:</span>
+                    <span className={playMode === "autocanonizer" ? "is-hidden" : ""}>{beatsPlayed}</span>
+                  </span>
                   {playMode === "jukebox" && bringItHomeMode ? (
                     <span className="bring-home-fullscreen-note">· Bringing it on home</span>
                   ) : null}

--- a/pwa/src/app/styles.css
+++ b/pwa/src/app/styles.css
@@ -29,6 +29,9 @@
   --edge-selected: #B48CFF;
   --beat-fill: #FFD46A;
   --beat-highlight: #FFD46A;
+  --scrim: rgba(10, 12, 16, 0.75);
+  --shadow-elevated: rgba(0, 0, 0, 0.35);
+  --danger: #E35A5A;
 }
 
 * {
@@ -241,7 +244,7 @@ textarea:focus-visible {
   }
   3% {
     opacity: 0.75;
-    border-color: color-mix(in srgb, var(--title-accent) 78%, black);
+    border-color: color-mix(in srgb, var(--title-accent) 78%, var(--bg));
     box-shadow:
       0 0 5px color-mix(in srgb, var(--title-glow) 78%, transparent),
       inset 0 0 3px color-mix(in srgb, var(--title-glow) 35%, transparent);
@@ -270,7 +273,7 @@ textarea:focus-visible {
   }
   44% {
     opacity: 0.7;
-    border-color: color-mix(in srgb, var(--title-accent) 74%, black);
+    border-color: color-mix(in srgb, var(--title-accent) 74%, var(--bg));
     box-shadow:
       0 0 4px color-mix(in srgb, var(--title-glow) 72%, transparent),
       inset 0 0 3px color-mix(in srgb, var(--title-glow) 30%, transparent);
@@ -705,12 +708,12 @@ textarea:focus-visible {
 }
 
 .branch-stats-delete {
-  color: #e35a5a;
+  color: var(--danger);
   pointer-events: auto;
 }
 
 .branch-stats-delete-icon {
-  color: #e35a5a;
+  color: var(--danger);
   width: 25px;
   height: 25px;
   line-height: 1;
@@ -913,6 +916,14 @@ textarea:focus-visible {
   color: var(--muted);
 }
 
+.viz-meta-stats {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 6px;
+  white-space: nowrap;
+}
+
 .viz-divider {
   color: var(--muted);
 }
@@ -1029,7 +1040,7 @@ textarea:focus-visible {
   background: var(--surface-panel);
   color: var(--text);
   font-size: 13px;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 8px 20px var(--shadow-elevated);
   z-index: 30;
 }
 
@@ -1039,7 +1050,7 @@ textarea:focus-visible {
   display: none;
   align-items: center;
   justify-content: center;
-  background: rgba(10, 12, 16, 0.75);
+  background: var(--scrim);
   z-index: 20;
 }
 
@@ -1380,6 +1391,12 @@ label {
   text-decoration: underline;
 }
 
+@media (max-width: 1024px) {
+  .menu-bar {
+    flex-wrap: wrap;
+  }
+}
+
 @media (max-width: 960px) {
   .hero-main {
     margin-top: 0;
@@ -1396,5 +1413,43 @@ label {
   .viz-top {
     flex-wrap: wrap;
     gap: 8px;
+  }
+}
+
+@media (max-width: 600px) {
+  .app {
+    margin: 0;
+    padding: 0;
+  }
+
+  .panel {
+    padding: 0;
+  }
+
+  .play-title {
+    padding-left: 6px;
+  }
+
+  #viz-stats {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  #viz-stats .viz-bottom-left {
+    display: contents;
+  }
+
+  #viz-stats .viz-play-toggle {
+    order: 1;
+  }
+
+  #viz-stats .viz-bottom-right {
+    order: 2;
+    margin-left: auto;
+  }
+
+  #viz-stats .viz-info {
+    order: 3;
+    flex: 0 0 100%;
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -317,6 +317,9 @@
             <div class="status-text" id="analysis-status">
               No track selected.
             </div>
+            <button id="saved-playlist" class="saved-playlist-button hidden" type="button">
+              Saved Playlist
+            </button>
           </div>
         </div>
         <div class="menu-bar hidden" id="play-menu">
@@ -464,36 +467,80 @@
             <div id="canonizer-layer" class="canonizer-layer"></div>
             <div class="viz-bottom" id="viz-stats">
               <div class="viz-bottom-left">
-                <button
-                  id="viz-play"
-                  class="play-toggle viz-play-toggle"
-                  aria-label="Play"
-                >
-                  <span
-                    class="material-symbols-outlined play-icon"
-                    aria-hidden="true"
-                    >play_arrow</span
+                <div class="viz-play-controls">
+                  <button
+                    id="playlist-previous"
+                    class="playlist-control is-hidden"
+                    type="button"
+                    aria-label="Previous playlist track"
+                    title="Previous playlist track"
                   >
-                </button>
+                    <span
+                      class="material-symbols-outlined playlist-control-icon"
+                      aria-hidden="true"
+                      >skip_previous</span
+                    >
+                  </button>
+                  <button
+                    id="viz-play"
+                    class="play-toggle viz-play-toggle"
+                    aria-label="Play"
+                  >
+                    <span
+                      class="material-symbols-outlined play-icon"
+                      aria-hidden="true"
+                      >play_arrow</span
+                    >
+                  </button>
+                  <button
+                    id="playlist-next"
+                    class="playlist-control is-hidden"
+                    type="button"
+                    aria-label="Next playlist track"
+                    title="Next playlist track"
+                  >
+                    <span
+                      class="material-symbols-outlined playlist-control-icon"
+                      aria-hidden="true"
+                      >skip_next</span
+                    >
+                  </button>
+                </div>
                 <div class="viz-info">
                   <div class="viz-title" id="viz-now-playing">
                     The Forever Jukebox
                   </div>
                   <div class="viz-meta">
-                    <span>Listen Time:</span>
-                    <span id="listen-time">00:00:00</span>
-                  <span id="viz-beats-divider" class="viz-divider">·</span>
-                  <span id="viz-beats-label">Total Beats:</span>
-                  <span id="beats-played">0</span>
-                  <span
-                    id="bring-home-fullscreen-label"
-                    class="bring-home-fullscreen-note is-hidden"
-                    >· Bringing it on home</span
-                  >
+                    <span class="viz-meta-stats">
+                      <span>Listen Time:</span>
+                      <span id="listen-time">00:00:00</span>
+                      <span id="viz-beats-divider" class="viz-divider">·</span>
+                      <span id="viz-beats-label">Total Beats:</span>
+                      <span id="beats-played">0</span>
+                    </span>
+                    <span
+                      id="bring-home-fullscreen-label"
+                      class="bring-home-fullscreen-note is-hidden"
+                      >· Bringing it on home</span
+                    >
+                  </div>
                 </div>
               </div>
-            </div>
-              <div>
+              <div class="viz-bottom-right">
+              <button
+                id="playlist-open"
+                class="playlist-control playlist-open-control is-hidden"
+                type="button"
+                aria-label="Playlist"
+                title="Playlist"
+              >
+                <span
+                  class="material-symbols-outlined playlist-control-icon"
+                  aria-hidden="true"
+                  >queue_music</span
+                >
+              </button>
+              <div class="volume-control-wrap">
                 <div class="volume-control-panel is-hidden" id="volume-control-panel">
                 <label>
                   <input
@@ -533,6 +580,7 @@
                   >fullscreen</span
                 >
               </button>
+              </div>
             </div>
           </div>
         </div>
@@ -651,6 +699,26 @@
             </li>
           </ul>
 
+          <h4>How do Playlists work?</h4>
+          <ul>
+            <li>
+              Load a track first, then use the add-circle button on Top,
+              Trending, Recently Played, or Favorites rows to build a playlist.
+            </li>
+            <li>
+              Use the playlist button on the Listen screen to open the playlist,
+              choose another track, remove non-current tracks, or clear the list.
+            </li>
+            <li>
+              Previous and next playlist buttons appear beside the play button
+              when an active playlist has another track available.
+            </li>
+            <li>
+              Playlists are saved only in this browser. They do not sync across
+              devices or accounts.
+            </li>
+          </ul>
+
           <h4>Installable Offline App</h4>
           <p>
             For local/offline analysis and playback, open the
@@ -669,6 +737,11 @@
             </li>
             <li>
               <strong>Favorites search & sorting</strong> added, maximum saved favorites bumped to 150 tracks.
+            </li>
+            <li>
+              Added local <strong>Playlists</strong>: queue up to 10
+              tracks from discovery lists or Favorites, then skip between them
+              from the Listen screen.
             </li>
           </ul>
 
@@ -1153,6 +1226,28 @@
             >
               Delete
             </button>
+          </div>
+        </div>
+      </div>
+      <div id="playlist-modal" class="modal" role="dialog" aria-modal="true">
+        <div class="modal-panel playlist-panel">
+          <div class="modal-header">
+            <h2>Playlist</h2>
+            <button id="playlist-close" class="modal-close" aria-label="Close">
+              <span
+                class="material-symbols-outlined modal-close-icon"
+                aria-hidden="true"
+                >close</span
+              >
+            </button>
+          </div>
+          <div class="modal-body">
+            <div id="playlist-list" class="playlist-list-wrap">
+              No playlist yet.
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button id="playlist-clear" type="button">Clear Playlist</button>
           </div>
         </div>
       </div>

--- a/web/src/app/bootstrap.ts
+++ b/web/src/app/bootstrap.ts
@@ -73,6 +73,7 @@ import { createSearchHandlers } from "./wire/search";
 import { createTuningHandlers } from "./wire/tuning";
 import { createFullscreenHandlers } from "./wire/fullscreen";
 import { createPlaybackUiHandlers } from "./wire/playback";
+import { createPlaylistHandlers, type PlaylistHandlers } from "./wire/playlist";
 import { createDeleteJobHandlers } from "./wire/delete-job";
 import { createTopSongsHandlers } from "./wire/top-songs";
 import { createThemeHandlers } from "./wire/theme";
@@ -96,6 +97,7 @@ import {
   saveFavorites,
   sortFavorites,
 } from "./favorites";
+import { loadPlaylist, type PlaylistTrack } from "./playlist";
 
 const vizStorageKey = "fj-viz";
 const canonizerFinishKey = "fj-canonizer-finish";
@@ -131,6 +133,7 @@ export function bootstrap() {
     playMode: "jukebox",
     topSongsTab: "top",
     favorites: loadFavorites(),
+    playlist: loadPlaylist(),
     favoritesSyncCode: loadFavoritesSyncCode(),
     playTimerMs: 0,
     lastPlayStamp: null,
@@ -186,6 +189,11 @@ export function bootstrap() {
     defaultConfig,
     state,
   };
+  let playlistHandlers: PlaylistHandlers | null = null;
+  const syncPlaylistUi = () => playlistHandlers?.syncPlaylistUi();
+  const handleNormalTrackSelected = (track: PlaylistTrack) => {
+    playlistHandlers?.handleNormalTrackSelected(track);
+  };
 
   const navigationHandlers = createNavigationHandlers({ context, state });
   const playbackHandlers = createPlaybackUiHandlers({
@@ -215,6 +223,8 @@ export function bootstrap() {
     updateTrackInfo,
     isEditableTarget,
     getCurrentTrackId: navigationHandlers.getCurrentTrackId,
+    advancePlaylistOnAutocanonizerEnded: () =>
+      playlistHandlers?.advanceAutocanonizerOnEnded() ?? Promise.resolve(false),
   });
   const playbackDeps: PlaybackDeps = {
     setActiveTab: (tabId: TabId) => navigationHandlers.setActiveTabWithRefresh(tabId),
@@ -250,21 +260,30 @@ export function bootstrap() {
     createFavoritesSync,
     updateFavoritesSync,
     navigateToTabWithState: navigationHandlers.navigateToTabWithState,
-    loadTrackById: (trackId) =>
+    loadTrackById: (trackId, options) =>
       loadTrackById(context, playbackDeps, trackId, {
         preserveUrlTuning: true,
+        ...options,
       }),
-    loadTrackByJobId: (jobId) =>
+    loadTrackByJobId: (jobId, options) =>
       loadTrackByJobId(context, playbackDeps, jobId, {
         preserveUrlTuning: true,
+        ...options,
       }),
     writeTuningParamsToUrl,
     syncTuningParamsState,
     setPlayMode: playbackHandlers.setPlayMode,
+    onAddToPlaylist: (track) => playlistHandlers?.handleAddToPlaylist(track),
   });
-  playbackDeps.onTrackChange = () => favoritesHandlers.syncFavoriteButton();
-  playbackDeps.onAnalysisLoaded = (response) =>
+  playbackDeps.onTrackChange = () => {
+    favoritesHandlers.syncFavoriteButton();
+    syncPlaylistUi();
+  };
+  playbackDeps.onAnalysisLoaded = (response) => {
     favoritesHandlers.maybeAutoFavoriteUserSupplied(response);
+    syncPlaylistUi();
+  };
+  playbackDeps.onPlaylistChange = syncPlaylistUi;
   const searchDeps: SearchDeps = {
     setActiveTab: (tabId: TabId) => navigationHandlers.setActiveTabWithRefresh(tabId),
     navigateToTab: (
@@ -283,24 +302,44 @@ export function bootstrap() {
       applyAnalysisResult(
         context,
         response,
-        favoritesHandlers.maybeAutoFavoriteUserSupplied,
+        (analysis) => {
+          favoritesHandlers.maybeAutoFavoriteUserSupplied(analysis);
+          syncPlaylistUi();
+        },
       ),
     loadAudioFromJob: (jobId: string) => loadAudioFromJob(context, jobId),
     resetForNewTrack: (options) => resetForNewTrack(context, options),
     updateVizVisibility: () => updateVizVisibility(context),
-    onTrackChange: () => favoritesHandlers.syncFavoriteButton(),
+    onTrackChange: () => {
+      favoritesHandlers.syncFavoriteButton();
+      syncPlaylistUi();
+    },
+    onNormalTrackSelected: handleNormalTrackSelected,
   };
+  playlistHandlers = createPlaylistHandlers({
+    context,
+    elements,
+    state,
+    showToast,
+    loadTrackById: (trackId, options) =>
+      loadTrackById(context, playbackDeps, trackId, options),
+    loadTrackByJobId: (jobId, options) =>
+      loadTrackByJobId(context, playbackDeps, jobId, options),
+    navigateToTabWithState: navigationHandlers.navigateToTabWithState,
+    togglePlayback,
+  });
   const topSongsHandlers = createTopSongsHandlers({
     elements,
     fetchTopSongs,
     fetchTrendingSongs,
     fetchRecentSongs,
     limit: TOP_SONGS_LIMIT,
-    loadTrackById: (trackId: string) =>
-      loadTrackById(context, playbackDeps, trackId),
-    loadTrackByJobId: (jobId: string) =>
-      loadTrackByJobId(context, playbackDeps, jobId),
+    loadTrackById: (trackId: string, options) =>
+      loadTrackById(context, playbackDeps, trackId, options),
+    loadTrackByJobId: (jobId: string, options) =>
+      loadTrackByJobId(context, playbackDeps, jobId, options),
     navigateToTabWithState: navigationHandlers.navigateToTabWithState,
+    onAddToPlaylist: (track) => playlistHandlers?.handleAddToPlaylist(track),
   });
   type LazyTopSongsTab = "top" | "trending" | "recent";
   const loadedTopSongTabs = new Set<LazyTopSongsTab>();
@@ -394,6 +433,7 @@ export function bootstrap() {
     updateTrackUrl,
     pollAnalysisJob: (jobId: string) =>
       pollAnalysis(context, playbackDeps, jobId),
+    onNormalTrackSelected: handleNormalTrackSelected,
   });
   const tuningHandlers = createTuningHandlers({
     context,
@@ -489,6 +529,7 @@ export function bootstrap() {
 
   resetForNewTrack(context);
   favoritesHandlers.syncFavoriteButton();
+  syncPlaylistUi();
 
   playbackHandlers.applyModeFromUrl();
   handleRouteChange(context, playbackDeps, window.location.pathname)
@@ -515,6 +556,7 @@ export function bootstrap() {
     deleteJobHandlers,
     themeHandlers,
     cacheHandlers,
+    playlistHandlers: playlistHandlers!,
   });
 
 }

--- a/web/src/app/context.ts
+++ b/web/src/app/context.ts
@@ -6,6 +6,7 @@ import type {
 import type { Edge } from "../engine/types";
 import type { getElements } from "./elements";
 import type { FavoriteTrack } from "./favorites";
+import type { PlaylistState } from "./playlist";
 import type { AppConfig } from "./api";
 import type { AutocanonizerController } from "../autocanonizer/AutocanonizerController";
 import type { JukeboxController } from "../jukebox/JukeboxController";
@@ -22,6 +23,7 @@ export type AppState = {
   topSongsTab: "top" | "trending" | "recent" | "favorites";
   searchTab: "search" | "upload";
   favorites: FavoriteTrack[];
+  playlist: PlaylistState;
   favoritesSyncCode: string | null;
   playTimerMs: number;
   lastPlayStamp: number | null;

--- a/web/src/app/elements.ts
+++ b/web/src/app/elements.ts
@@ -117,6 +117,38 @@ export function getElements() {
     document.querySelector<HTMLButtonElement>("#favorite-toggle"),
     "#favorite-toggle"
   );
+  const playlistPreviousButton = requireElement(
+    document.querySelector<HTMLButtonElement>("#playlist-previous"),
+    "#playlist-previous"
+  );
+  const playlistNextButton = requireElement(
+    document.querySelector<HTMLButtonElement>("#playlist-next"),
+    "#playlist-next"
+  );
+  const playlistButton = requireElement(
+    document.querySelector<HTMLButtonElement>("#playlist-open"),
+    "#playlist-open"
+  );
+  const savedPlaylistButton = requireElement(
+    document.querySelector<HTMLButtonElement>("#saved-playlist"),
+    "#saved-playlist"
+  );
+  const playlistModal = requireElement(
+    document.querySelector<HTMLDivElement>("#playlist-modal"),
+    "#playlist-modal"
+  );
+  const playlistClose = requireElement(
+    document.querySelector<HTMLButtonElement>("#playlist-close"),
+    "#playlist-close"
+  );
+  const playlistList = requireElement(
+    document.querySelector<HTMLDivElement>("#playlist-list"),
+    "#playlist-list"
+  );
+  const playlistClearButton = requireElement(
+    document.querySelector<HTMLButtonElement>("#playlist-clear"),
+    "#playlist-clear"
+  );
   const deleteButton = requireElement(
     document.querySelector<HTMLButtonElement>("#delete-job"),
     "#delete-job"
@@ -630,6 +662,14 @@ export function getElements() {
     tuningButton,
     infoButton,
     favoriteButton,
+    playlistPreviousButton,
+    playlistNextButton,
+    playlistButton,
+    savedPlaylistButton,
+    playlistModal,
+    playlistClose,
+    playlistList,
+    playlistClearButton,
     deleteButton,
     deleteConfirmModal,
     deleteConfirmCancel,

--- a/web/src/app/playback.test.ts
+++ b/web/src/app/playback.test.ts
@@ -1574,6 +1574,7 @@ describe("playback loading", () => {
       setAnalysisStatus: vi.fn(),
       setLoadingProgress: vi.fn(),
       onTrackChange: vi.fn(),
+      onPlaylistChange: vi.fn(),
     };
   }
 
@@ -1607,6 +1608,175 @@ describe("playback loading", () => {
     expect((fetch as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).toBe(
       `/api/analysis/${jobId}`,
     );
+  });
+
+  it("marks the matching saved playlist item current on preserved route loads", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const context = createContext();
+    context.state.playlist = {
+      tracks: [
+        {
+          id: "first",
+          sourceType: "youtube",
+          title: "First",
+          artist: "",
+          duration: null,
+        },
+        {
+          id: "sc-123",
+          sourceType: "soundcloud",
+          title: "SoundCloud Track",
+          artist: "",
+          duration: null,
+        },
+      ],
+      currentIndex: -1,
+    };
+    const deps = createLoadDeps();
+
+    await loadTrackById(context, deps, "soundcloud:sc-123", {
+      preservePlaylist: true,
+    });
+
+    expect(context.state.playlist.currentIndex).toBe(1);
+    expect(deps.onPlaylistChange).toHaveBeenCalledOnce();
+  });
+
+  it("appends missing route-loaded tracks to saved playlists", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const context = createContext();
+    context.state.playlist = {
+      tracks: [
+        {
+          id: "saved-a",
+          sourceType: "youtube",
+          title: "Saved A",
+          artist: "",
+          duration: null,
+        },
+        {
+          id: "saved-b",
+          sourceType: "youtube",
+          title: "Saved B",
+          artist: "",
+          duration: null,
+        },
+      ],
+      currentIndex: -1,
+    };
+    const deps = createLoadDeps();
+
+    await loadTrackById(context, deps, "outside", {
+      preservePlaylist: true,
+    });
+
+    expect(context.state.playlist.currentIndex).toBe(2);
+    expect(context.state.playlist.tracks.map((track) => track.id)).toEqual([
+      "saved-a",
+      "saved-b",
+      "outside",
+    ]);
+    expect(deps.onPlaylistChange).toHaveBeenCalledOnce();
+    expect(localStorage.getItem("fj-playlist")).toContain("outside");
+  });
+
+  it("replaces the final saved playlist slot for missing route-loaded tracks when full", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const context = createContext();
+    context.state.playlist = {
+      tracks: Array.from({ length: 10 }, (_, index) => ({
+        id: `saved-${index}`,
+        sourceType: "youtube" as const,
+        title: `Saved ${index}`,
+        artist: "",
+        duration: null,
+      })),
+      currentIndex: -1,
+    };
+    const deps = createLoadDeps();
+
+    await loadTrackById(context, deps, "outside", {
+      preservePlaylist: true,
+    });
+
+    expect(context.state.playlist.currentIndex).toBe(9);
+    expect(context.state.playlist.tracks).toHaveLength(10);
+    expect(context.state.playlist.tracks[9]?.id).toBe("outside");
+    expect(context.state.playlist.tracks[8]?.id).toBe("saved-8");
+    expect(deps.onPlaylistChange).toHaveBeenCalledOnce();
+  });
+
+  it("replaces only the current active playlist item on normal track loads", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const context = createContext();
+    context.state.playlist = {
+      tracks: [
+        {
+          id: "current",
+          sourceType: "youtube",
+          title: "Current",
+          artist: "",
+          duration: null,
+        },
+        {
+          id: "next",
+          sourceType: "youtube",
+          title: "Next",
+          artist: "",
+          duration: null,
+        },
+      ],
+      currentIndex: 0,
+    };
+    const deps = createLoadDeps();
+
+    await loadTrackById(context, deps, "outside", {
+      selectedTrack: {
+        id: "outside",
+        sourceType: "youtube",
+        title: "Outside",
+        artist: "",
+        duration: null,
+      },
+    });
+
+    expect(context.state.playlist.currentIndex).toBe(0);
+    expect(context.state.playlist.tracks.map((track) => track.id)).toEqual([
+      "outside",
+      "next",
+    ]);
+    expect(deps.onPlaylistChange).toHaveBeenCalledOnce();
+  });
+
+  it("clears inactive saved playlists on normal track loads", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const context = createContext();
+    context.state.playlist = {
+      tracks: [
+        {
+          id: "saved-a",
+          sourceType: "youtube",
+          title: "Saved A",
+          artist: "",
+          duration: null,
+        },
+        {
+          id: "saved-b",
+          sourceType: "youtube",
+          title: "Saved B",
+          artist: "",
+          duration: null,
+        },
+      ],
+      currentIndex: -1,
+    };
+    const deps = createLoadDeps();
+
+    await loadTrackById(context, deps, "outside");
+
+    expect(context.state.playlist.tracks).toEqual([]);
+    expect(context.state.playlist.currentIndex).toBe(-1);
+    expect(deps.onPlaylistChange).toHaveBeenCalledOnce();
   });
 
   it("returns false on missing audio without calling repair endpoint", async () => {

--- a/web/src/app/playback.ts
+++ b/web/src/app/playback.ts
@@ -1399,10 +1399,10 @@ async function continueTrackLoadWithResponse(
   context: AppContext,
   deps: PlaybackDeps,
   response: AnalysisResponse | null,
-) {
+): Promise<boolean> {
   if (!response || !response.id) {
     deps.setAnalysisStatus(GENERIC_LOAD_ERROR_MESSAGE, false);
-    return;
+    return false;
   }
   maybeUpdateDeleteEligibility(context, response, response.id);
   context.state.lastJobId = response.id;
@@ -1421,26 +1421,43 @@ async function continueTrackLoadWithResponse(
     response.source_provider !== "youtube" &&
     response.id
   ) {
-    context.state.lastTrackId = response.id;
-    deps.onTrackChange?.(response.id);
+    const trackId =
+      typeof response.source_id === "string" && response.source_id
+        ? `${response.source_provider}:${response.source_id}`
+        : response.id;
+    context.state.lastTrackId = trackId;
+    deps.onTrackChange?.(trackId);
   }
   if (isAnalysisInProgress(response)) {
     await pollAnalysis(context, deps, response.id);
-    return;
+    return true;
+  }
+  if (isAnalysisFailed(response)) {
+    deps.setAnalysisStatus(
+      formatErrorForDisplay(response.error, {
+        sourceProvider: response.source_provider,
+        errorCode: response.error_code,
+        fallback: "Loading failed.",
+      }),
+      false,
+    );
+    return false;
   }
   if (isAnalysisComplete(response)) {
     if (!context.state.audioLoaded) {
       const audioLoaded = await loadAudioFromJob(context, response.id);
       if (!audioLoaded) {
         await pollAnalysis(context, deps, response.id);
-        return;
+        return true;
       }
     }
-    applyAnalysisResult(context, response, deps.onAnalysisLoaded);
+    if (!applyAnalysisResult(context, response, deps.onAnalysisLoaded)) {
+      return false;
+    }
     deps.setActiveTab("play");
-    return;
+    return true;
   }
-  await pollAnalysis(context, deps, response.id);
+  return false;
 }
 
 async function loadTrack(
@@ -1450,7 +1467,7 @@ async function loadTrack(
     | { type: "source"; id: string; provider: string; trackId: string }
     | { type: "job"; id: string },
   options?: TrackLoadOptions,
-) {
+): Promise<boolean> {
   const shouldClear = !options?.preserveUrlTuning;
   handlePlaylistForNormalTrackLoad(context, deps, source, options);
   resetForNewTrack(context, { clearTuning: shouldClear });
@@ -1476,9 +1493,10 @@ async function loadTrack(
       source.type === "source"
         ? await fetchJobBySource(source.provider, source.id)
         : await fetchAnalysis(source.id);
-    await continueTrackLoadWithResponse(context, deps, response);
+    return await continueTrackLoadWithResponse(context, deps, response);
   } catch (err) {
     deps.setAnalysisStatus(`Load failed: ${formatErrorForDisplay(err)}`, false);
+    return false;
   }
 }
 
@@ -1490,10 +1508,9 @@ export async function loadTrackById(
 ) {
   const parsed = parseTrackId(trackId);
   if (parsed.type === "job") {
-    await loadTrack(context, deps, { type: "job", id: parsed.jobId }, options);
-    return;
+    return await loadTrack(context, deps, { type: "job", id: parsed.jobId }, options);
   }
-  await loadTrack(
+  return await loadTrack(
     context,
     deps,
     {
@@ -1512,7 +1529,7 @@ export async function loadTrackByJobId(
   jobId: string,
   options?: TrackLoadOptions,
 ) {
-  await loadTrack(context, deps, { type: "job", id: jobId }, options);
+  return await loadTrack(context, deps, { type: "job", id: jobId }, options);
 }
 
 function isLikelyJobId(value: string) {

--- a/web/src/app/playback.ts
+++ b/web/src/app/playback.ts
@@ -31,6 +31,18 @@ import { setAutoMarqueeText } from "./marquee";
 import { showToast } from "./ui";
 import { isAdminMode } from "./admin";
 import {
+  activatePlaylistTrack,
+  emptyPlaylist,
+  hasInactiveSavedPlaylist,
+  isPlaylistActive,
+  PLAYLIST_MAX_TRACKS,
+  playlistTrackKey,
+  replaceActivePlaylistTrack,
+  savePlaylist,
+  type PlaylistSourceType,
+  type PlaylistTrack,
+} from "./playlist";
+import {
   isAnalysisComplete,
   isAnalysisFailed,
   isAnalysisInProgress,
@@ -241,6 +253,14 @@ export type PlaybackDeps = {
   ) => void;
   onTrackChange?: (trackId: string | null) => void;
   onAnalysisLoaded?: (response: AnalysisComplete) => void;
+  onPlaylistChange?: () => void;
+};
+
+export type TrackLoadOptions = {
+  preserveUrlTuning?: boolean;
+  playlistLoad?: boolean;
+  preservePlaylist?: boolean;
+  selectedTrack?: PlaylistTrack | null;
 };
 
 export function updateListenTimeDisplay(context: AppContext) {
@@ -1278,6 +1298,8 @@ export function applyAnalysisResult(
     setAutoMarqueeText(elements.vizNowPlayingEl, "The Forever Jukebox");
   }
   updateTrackInfo(context);
+  syncActivePlaylistTrackFromLoaded(context);
+  savePlaylist(state.playlist);
   onAnalysisLoaded?.(response);
   if (state.playMode === "jukebox") {
     writeTuningParamsToUrl(state.tuningParams, true);
@@ -1427,9 +1449,10 @@ async function loadTrack(
   source:
     | { type: "source"; id: string; provider: string; trackId: string }
     | { type: "job"; id: string },
-  options?: { preserveUrlTuning?: boolean },
+  options?: TrackLoadOptions,
 ) {
   const shouldClear = !options?.preserveUrlTuning;
+  handlePlaylistForNormalTrackLoad(context, deps, source, options);
   resetForNewTrack(context, { clearTuning: shouldClear });
   deps.setActiveTab("play");
   deps.setLoadingProgress(null, "Fetching audio");
@@ -1463,7 +1486,7 @@ export async function loadTrackById(
   context: AppContext,
   deps: PlaybackDeps,
   trackId: string,
-  options?: { preserveUrlTuning?: boolean },
+  options?: TrackLoadOptions,
 ) {
   const parsed = parseTrackId(trackId);
   if (parsed.type === "job") {
@@ -1487,7 +1510,7 @@ export async function loadTrackByJobId(
   context: AppContext,
   deps: PlaybackDeps,
   jobId: string,
-  options?: { preserveUrlTuning?: boolean },
+  options?: TrackLoadOptions,
 ) {
   await loadTrack(context, deps, { type: "job", id: jobId }, options);
 }
@@ -1502,12 +1525,161 @@ function parseTrackId(trackId: string):
   if (isLikelyJobId(trackId)) {
     return { type: "job", jobId: trackId };
   }
+  const prefixed = /^([a-z]+):(.+)$/.exec(trackId);
+  if (
+    prefixed &&
+    (prefixed[1] === "youtube" ||
+      prefixed[1] === "soundcloud" ||
+      prefixed[1] === "bandcamp")
+  ) {
+    return {
+      type: "source",
+      provider: prefixed[1],
+      sourceId: prefixed[2],
+      trackId,
+    };
+  }
   return {
     type: "source",
     provider: "youtube",
     sourceId: trackId,
     trackId,
   };
+}
+
+function handlePlaylistForNormalTrackLoad(
+  context: AppContext,
+  deps: PlaybackDeps,
+  source:
+    | { type: "source"; id: string; provider: string; trackId: string }
+    | { type: "job"; id: string },
+  options?: TrackLoadOptions,
+) {
+  if (options?.playlistLoad) {
+    return;
+  }
+  if (options?.preservePlaylist) {
+    reconcilePreservedPlaylistTrack(context, deps, source);
+    return;
+  }
+  const { state } = context;
+  const playlist = state.playlist ?? emptyPlaylist();
+  state.playlist = playlist;
+  if (isPlaylistActive(playlist)) {
+    const track =
+      options?.selectedTrack ?? playlistTrackFromLoadSource(source, state.tuningParams);
+    state.playlist = replaceActivePlaylistTrack(playlist, track);
+    savePlaylist(state.playlist);
+    deps.onPlaylistChange?.();
+    return;
+  }
+  if (hasInactiveSavedPlaylist(playlist)) {
+    state.playlist = emptyPlaylist();
+    savePlaylist(state.playlist);
+    deps.onPlaylistChange?.();
+  }
+}
+
+function reconcilePreservedPlaylistTrack(
+  context: AppContext,
+  deps: PlaybackDeps,
+  source:
+    | { type: "source"; id: string; provider: string; trackId: string }
+    | { type: "job"; id: string },
+) {
+  const playlist = context.state.playlist ?? emptyPlaylist();
+  context.state.playlist = playlist;
+  if (playlist.tracks.length < 2) {
+    return;
+  }
+  const sourceKey = playlistTrackKey(playlistTrackIdentityFromLoadSource(source));
+  const matchingIndex = playlist.tracks.findIndex(
+    (track) => playlistTrackKey(track) === sourceKey,
+  );
+  if (matchingIndex >= 0) {
+    if (playlist.currentIndex === matchingIndex) {
+      return;
+    }
+    context.state.playlist = activatePlaylistTrack(playlist, matchingIndex);
+    deps.onPlaylistChange?.();
+    return;
+  }
+
+  const nextTracks = playlist.tracks.slice(0, PLAYLIST_MAX_TRACKS);
+  const nextTrack = playlistTrackFromLoadSource(source, context.state.tuningParams);
+  let nextCurrentIndex = nextTracks.length;
+  if (nextTracks.length >= PLAYLIST_MAX_TRACKS) {
+    nextCurrentIndex = PLAYLIST_MAX_TRACKS - 1;
+    nextTracks[nextCurrentIndex] = nextTrack;
+  } else {
+    nextTracks.push(nextTrack);
+  }
+  context.state.playlist = {
+    tracks: nextTracks,
+    currentIndex: nextCurrentIndex,
+  };
+  savePlaylist(context.state.playlist);
+  deps.onPlaylistChange?.();
+}
+
+function playlistTrackFromLoadSource(
+  source:
+    | { type: "source"; id: string; provider: string; trackId: string }
+    | { type: "job"; id: string },
+  tuningParams: string | null,
+): PlaylistTrack {
+  const identity = playlistTrackIdentityFromLoadSource(source);
+  return {
+    ...identity,
+    title: "Untitled",
+    artist: "",
+    duration: null,
+    tuningParams,
+  };
+}
+
+function playlistTrackIdentityFromLoadSource(
+  source:
+    | { type: "source"; id: string; provider: string; trackId: string }
+    | { type: "job"; id: string },
+): Pick<PlaylistTrack, "id" | "sourceType"> {
+  if (source.type === "job") {
+    return { id: source.id, sourceType: "upload" };
+  }
+  return {
+    id: source.id,
+    sourceType: playlistSourceTypeFromProvider(source.provider),
+  };
+}
+
+function playlistSourceTypeFromProvider(provider: string): PlaylistSourceType {
+  if (provider === "soundcloud" || provider === "bandcamp") {
+    return provider;
+  }
+  if (provider === "upload") {
+    return "upload";
+  }
+  return "youtube";
+}
+
+function syncActivePlaylistTrackFromLoaded(context: AppContext) {
+  const { state } = context;
+  const playlist = state.playlist ?? emptyPlaylist();
+  state.playlist = playlist;
+  if (!isPlaylistActive(playlist)) {
+    return;
+  }
+  const track = playlist.tracks[playlist.currentIndex];
+  if (!track) {
+    return;
+  }
+  state.playlist = replaceActivePlaylistTrack(state.playlist, {
+    ...track,
+    title: state.trackTitle || track.title || "Untitled",
+    artist: state.trackArtist || track.artist || "",
+    duration: state.trackDurationSec,
+    tuningParams: state.playMode === "jukebox" ? state.tuningParams : null,
+  });
 }
 
 export function requestWakeLock(context: AppContext) {

--- a/web/src/app/playlist.test.ts
+++ b/web/src/app/playlist.test.ts
@@ -74,6 +74,13 @@ describe("playlist", () => {
     expect(result.playlist.tracks).toEqual([]);
   });
 
+  it("rejects invalid tracks separately from duplicates", () => {
+    const result = addPlaylistTrack(emptyPlaylist(), track("current"), track(""));
+
+    expect(result.status).toBe("invalid");
+    expect(result.playlist.tracks).toEqual([]);
+  });
+
   it("blocks duplicates and max size", () => {
     let playlist = {
       tracks: [track("0"), track("1")],

--- a/web/src/app/playlist.test.ts
+++ b/web/src/app/playlist.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  PLAYLIST_MAX_TRACKS,
+  PLAYLIST_STORAGE_KEY,
+  activatePlaylistTrack,
+  addPlaylistTrack,
+  canMovePlaylistNext,
+  canMovePlaylistPrevious,
+  emptyPlaylist,
+  hasInactiveSavedPlaylist,
+  loadPlaylist,
+  playlistTrackKey,
+  removePlaylistTrack,
+  replaceActivePlaylistTrack,
+  savePlaylist,
+  type PlaylistTrack,
+} from "./playlist";
+
+function setLocalStorage() {
+  const store = new Map<string, string>();
+  globalThis.localStorage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  } as Storage;
+  return store;
+}
+
+function track(
+  id: string,
+  sourceType: PlaylistTrack["sourceType"] = "youtube",
+): PlaylistTrack {
+  return {
+    id,
+    sourceType,
+    title: `Track ${id}`,
+    artist: "Artist",
+    duration: null,
+  };
+}
+
+describe("playlist", () => {
+  beforeEach(() => {
+    setLocalStorage();
+  });
+
+  it("uses source type and trimmed id for duplicate keys", () => {
+    expect(playlistTrackKey(track(" abc "))).toBe("youtube:abc");
+    expect(playlistTrackKey(track("abc", "upload"))).toBe("upload:abc");
+  });
+
+  it("initializes from the current track and added track", () => {
+    const result = addPlaylistTrack(emptyPlaylist(), track("current"), track("next"));
+
+    expect(result.status).toBe("added");
+    expect(result.playlist.currentIndex).toBe(0);
+    expect(result.playlist.tracks.map((item) => item.id)).toEqual([
+      "current",
+      "next",
+    ]);
+  });
+
+  it("requires a current track for first add", () => {
+    const result = addPlaylistTrack(emptyPlaylist(), null, track("next"));
+
+    expect(result.status).toBe("no-current");
+    expect(result.playlist.tracks).toEqual([]);
+  });
+
+  it("blocks duplicates and max size", () => {
+    let playlist = {
+      tracks: [track("0"), track("1")],
+      currentIndex: 0,
+    };
+    const duplicate = addPlaylistTrack(playlist, track("0"), track(" 1 "));
+    expect(duplicate.status).toBe("duplicate");
+
+    playlist = {
+      tracks: Array.from({ length: PLAYLIST_MAX_TRACKS }, (_, index) =>
+        track(`${index}`),
+      ),
+      currentIndex: 0,
+    };
+    const full = addPlaylistTrack(playlist, track("0"), track("extra"));
+    expect(full.status).toBe("full");
+  });
+
+  it("activates tracks and reports adjacent availability", () => {
+    let playlist = {
+      tracks: [track("0"), track("1"), track("2")],
+      currentIndex: -1,
+    };
+    expect(hasInactiveSavedPlaylist(playlist)).toBe(true);
+
+    playlist = activatePlaylistTrack(playlist, 1);
+    expect(playlist.currentIndex).toBe(1);
+    expect(canMovePlaylistPrevious(playlist)).toBe(true);
+    expect(canMovePlaylistNext(playlist)).toBe(true);
+
+    playlist = activatePlaylistTrack(playlist, 2);
+    expect(canMovePlaylistNext(playlist)).toBe(false);
+  });
+
+  it("replaces the active track and removes an older duplicate", () => {
+    const playlist = {
+      tracks: [track("a"), track("b"), track("c")],
+      currentIndex: 1,
+    };
+    const next = replaceActivePlaylistTrack(playlist, track("a"));
+
+    expect(next.currentIndex).toBe(0);
+    expect(next.tracks.map((item) => item.id)).toEqual(["a", "c"]);
+  });
+
+  it("removes non-current tracks and adjusts current index", () => {
+    const playlist = {
+      tracks: [track("a"), track("b"), track("c")],
+      currentIndex: 2,
+    };
+    const next = removePlaylistTrack(playlist, 0);
+
+    expect(next.currentIndex).toBe(1);
+    expect(next.tracks.map((item) => item.id)).toEqual(["b", "c"]);
+  });
+
+  it("does not remove current track and clears when fewer than two remain", () => {
+    const playlist = {
+      tracks: [track("a"), track("b")],
+      currentIndex: 0,
+    };
+
+    expect(removePlaylistTrack(playlist, 0)).toBe(playlist);
+    expect(removePlaylistTrack(playlist, 1)).toEqual(emptyPlaylist());
+  });
+
+  it("saves, restores as inactive, and ignores malformed payloads", () => {
+    const playlist = {
+      tracks: [track("a"), track("b")],
+      currentIndex: 1,
+    };
+
+    savePlaylist(playlist);
+    expect(loadPlaylist()).toEqual({
+      tracks: playlist.tracks,
+      currentIndex: -1,
+    });
+
+    localStorage.setItem(PLAYLIST_STORAGE_KEY, "{nope");
+    expect(loadPlaylist()).toEqual(emptyPlaylist());
+  });
+
+  it("clears saved playlists with fewer than two valid tracks", () => {
+    const store = setLocalStorage();
+    localStorage.setItem(
+      PLAYLIST_STORAGE_KEY,
+      JSON.stringify({ tracks: [track("a")] }),
+    );
+
+    expect(loadPlaylist()).toEqual(emptyPlaylist());
+    expect(store.has(PLAYLIST_STORAGE_KEY)).toBe(false);
+  });
+});

--- a/web/src/app/playlist.ts
+++ b/web/src/app/playlist.ts
@@ -1,0 +1,261 @@
+export type PlaylistSourceType = "youtube" | "soundcloud" | "bandcamp" | "upload";
+
+export type PlaylistTrack = {
+  id: string;
+  sourceType: PlaylistSourceType;
+  title: string;
+  artist: string;
+  duration: number | null;
+  tuningParams?: string | null;
+};
+
+export type PlaylistState = {
+  tracks: PlaylistTrack[];
+  currentIndex: number;
+};
+
+export type PlaylistAddStatus =
+  | "added"
+  | "duplicate"
+  | "full"
+  | "no-current";
+
+export const PLAYLIST_STORAGE_KEY = "fj-playlist";
+export const PLAYLIST_MAX_TRACKS = 10;
+
+export function emptyPlaylist(): PlaylistState {
+  return { tracks: [], currentIndex: -1 };
+}
+
+export function playlistTrackKey(track: Pick<PlaylistTrack, "id" | "sourceType">) {
+  return `${track.sourceType}:${track.id.trim()}`;
+}
+
+export function isPlaylistActive(playlist: PlaylistState) {
+  return (
+    playlist.currentIndex >= 0 &&
+    playlist.currentIndex < playlist.tracks.length
+  );
+}
+
+export function hasInactiveSavedPlaylist(playlist: PlaylistState) {
+  return playlist.tracks.length >= 2 && !isPlaylistActive(playlist);
+}
+
+export function hasPlaylistControls(playlist: PlaylistState) {
+  return playlist.tracks.length > 1;
+}
+
+export function hasActivePlaylistControls(playlist: PlaylistState) {
+  return hasPlaylistControls(playlist) && isPlaylistActive(playlist);
+}
+
+export function canMovePlaylistPrevious(playlist: PlaylistState) {
+  return hasActivePlaylistControls(playlist) && playlist.currentIndex > 0;
+}
+
+export function canMovePlaylistNext(playlist: PlaylistState) {
+  return (
+    hasActivePlaylistControls(playlist) &&
+    playlist.currentIndex < playlist.tracks.length - 1
+  );
+}
+
+export function normalizePlaylistTrack(track: PlaylistTrack): PlaylistTrack | null {
+  const id = typeof track.id === "string" ? track.id.trim() : "";
+  if (!id || !isPlaylistSourceType(track.sourceType)) {
+    return null;
+  }
+  const title =
+    typeof track.title === "string" && track.title.trim()
+      ? track.title.trim()
+      : "Untitled";
+  const artist = typeof track.artist === "string" ? track.artist.trim() : "";
+  const duration =
+    typeof track.duration === "number" && Number.isFinite(track.duration)
+      ? track.duration
+      : null;
+  const tuningParams =
+    typeof track.tuningParams === "string" && track.tuningParams.trim()
+      ? track.tuningParams
+      : null;
+  const normalized: PlaylistTrack = {
+    id,
+    sourceType: track.sourceType,
+    title,
+    artist,
+    duration,
+  };
+  if (tuningParams) {
+    normalized.tuningParams = tuningParams;
+  }
+  return normalized;
+}
+
+export function addPlaylistTrack(
+  playlist: PlaylistState,
+  currentTrack: PlaylistTrack | null,
+  track: PlaylistTrack,
+): { playlist: PlaylistState; status: PlaylistAddStatus } {
+  const normalizedTrack = normalizePlaylistTrack(track);
+  const normalizedCurrent = currentTrack
+    ? normalizePlaylistTrack(currentTrack)
+    : null;
+  if (!normalizedTrack) {
+    return { playlist, status: "duplicate" };
+  }
+  const existingTracks = playlist.tracks;
+  const existingKeys = new Set(existingTracks.map(playlistTrackKey));
+  if (existingKeys.has(playlistTrackKey(normalizedTrack))) {
+    return { playlist, status: "duplicate" };
+  }
+  if (existingTracks.length === 0) {
+    if (!normalizedCurrent) {
+      return { playlist, status: "no-current" };
+    }
+    if (playlistTrackKey(normalizedCurrent) === playlistTrackKey(normalizedTrack)) {
+      return { playlist, status: "duplicate" };
+    }
+    return {
+      playlist: {
+        tracks: [normalizedCurrent, normalizedTrack],
+        currentIndex: 0,
+      },
+      status: "added",
+    };
+  }
+  if (existingTracks.length >= PLAYLIST_MAX_TRACKS) {
+    return { playlist, status: "full" };
+  }
+  return {
+    playlist: {
+      tracks: [...existingTracks, normalizedTrack],
+      currentIndex: playlist.currentIndex,
+    },
+    status: "added",
+  };
+}
+
+export function activatePlaylistTrack(
+  playlist: PlaylistState,
+  index: number,
+): PlaylistState {
+  if (index < 0 || index >= playlist.tracks.length) {
+    return playlist;
+  }
+  return { ...playlist, currentIndex: index };
+}
+
+export function replaceActivePlaylistTrack(
+  playlist: PlaylistState,
+  track: PlaylistTrack,
+): PlaylistState {
+  if (!isPlaylistActive(playlist)) {
+    return emptyPlaylist();
+  }
+  const normalized = normalizePlaylistTrack(track);
+  if (!normalized) {
+    return playlist;
+  }
+  const currentIndex = playlist.currentIndex;
+  const nextTracks = playlist.tracks.slice();
+  nextTracks[currentIndex] = normalized;
+  const replacementKey = playlistTrackKey(normalized);
+  const duplicateIndex = nextTracks.findIndex(
+    (candidate, index) =>
+      index !== currentIndex && playlistTrackKey(candidate) === replacementKey,
+  );
+  let nextCurrentIndex = currentIndex;
+  if (duplicateIndex >= 0) {
+    nextTracks.splice(duplicateIndex, 1);
+    if (duplicateIndex < nextCurrentIndex) {
+      nextCurrentIndex -= 1;
+    }
+  }
+  if (nextTracks.length < 2) {
+    return emptyPlaylist();
+  }
+  return { tracks: nextTracks, currentIndex: nextCurrentIndex };
+}
+
+export function removePlaylistTrack(
+  playlist: PlaylistState,
+  index: number,
+): PlaylistState {
+  if (index < 0 || index >= playlist.tracks.length) {
+    return playlist;
+  }
+  if (index === playlist.currentIndex) {
+    return playlist;
+  }
+  const nextTracks = playlist.tracks.filter((_, itemIndex) => itemIndex !== index);
+  if (nextTracks.length < 2) {
+    return emptyPlaylist();
+  }
+  const nextCurrentIndex =
+    playlist.currentIndex > index
+      ? playlist.currentIndex - 1
+      : playlist.currentIndex;
+  return { tracks: nextTracks, currentIndex: nextCurrentIndex };
+}
+
+export function loadPlaylist(): PlaylistState {
+  const raw = localStorage.getItem(PLAYLIST_STORAGE_KEY);
+  if (!raw) {
+    return emptyPlaylist();
+  }
+  try {
+    const parsed = JSON.parse(raw) as { tracks?: PlaylistTrack[] };
+    const rawTracks = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(parsed.tracks)
+        ? parsed.tracks
+        : [];
+    const tracks = normalizePlaylistTracks(rawTracks).slice(0, PLAYLIST_MAX_TRACKS);
+    if (tracks.length < 2) {
+      localStorage.removeItem(PLAYLIST_STORAGE_KEY);
+      return emptyPlaylist();
+    }
+    return { tracks, currentIndex: -1 };
+  } catch {
+    return emptyPlaylist();
+  }
+}
+
+export function savePlaylist(playlist: PlaylistState) {
+  if (playlist.tracks.length < 2) {
+    localStorage.removeItem(PLAYLIST_STORAGE_KEY);
+    return;
+  }
+  localStorage.setItem(
+    PLAYLIST_STORAGE_KEY,
+    JSON.stringify({ tracks: playlist.tracks.slice(0, PLAYLIST_MAX_TRACKS) }),
+  );
+}
+
+function normalizePlaylistTracks(tracks: PlaylistTrack[]) {
+  const seen = new Set<string>();
+  const normalized: PlaylistTrack[] = [];
+  for (const track of tracks) {
+    const item = normalizePlaylistTrack(track);
+    if (!item) {
+      continue;
+    }
+    const key = playlistTrackKey(item);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    normalized.push(item);
+  }
+  return normalized;
+}
+
+function isPlaylistSourceType(value: unknown): value is PlaylistSourceType {
+  return (
+    value === "youtube" ||
+    value === "soundcloud" ||
+    value === "bandcamp" ||
+    value === "upload"
+  );
+}

--- a/web/src/app/playlist.ts
+++ b/web/src/app/playlist.ts
@@ -18,6 +18,7 @@ export type PlaylistAddStatus =
   | "added"
   | "duplicate"
   | "full"
+  | "invalid"
   | "no-current";
 
 export const PLAYLIST_STORAGE_KEY = "fj-playlist";
@@ -102,7 +103,7 @@ export function addPlaylistTrack(
     ? normalizePlaylistTrack(currentTrack)
     : null;
   if (!normalizedTrack) {
-    return { playlist, status: "duplicate" };
+    return { playlist, status: "invalid" };
   }
   const existingTracks = playlist.tracks;
   const existingKeys = new Set(existingTracks.map(playlistTrackKey));

--- a/web/src/app/routing.test.ts
+++ b/web/src/app/routing.test.ts
@@ -64,7 +64,7 @@ describe("routing", () => {
       context,
       deps,
       "abc123def45",
-      { preserveUrlTuning: true },
+      { preservePlaylist: true, preserveUrlTuning: true },
     );
   });
 
@@ -78,7 +78,7 @@ describe("routing", () => {
       context,
       deps,
       jobId,
-      { preserveUrlTuning: false },
+      { preservePlaylist: true, preserveUrlTuning: false },
     );
   });
 

--- a/web/src/app/routing.ts
+++ b/web/src/app/routing.ts
@@ -41,7 +41,10 @@ export async function handleRouteChange(
         return;
       }
       deps.navigateToTab("play", { replace: true, trackId });
-      await loadTrackById(context, deps, trackId, { preserveUrlTuning });
+      await loadTrackById(context, deps, trackId, {
+        preserveUrlTuning,
+        preservePlaylist: true,
+      });
       return;
     }
     deps.navigateToTab("top", { replace: true });

--- a/web/src/app/search.test.ts
+++ b/web/src/app/search.test.ts
@@ -1,11 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppContext } from "./context";
 import type { SearchDeps } from "./search";
-import { startYoutubeAnalysisFlow, tryLoadExistingTrackByName } from "./search";
+import {
+  showYoutubeMatches,
+  startYoutubeAnalysisFlow,
+  tryLoadExistingTrackByName,
+} from "./search";
 import { setWindowUrl } from "./__tests__/test-utils";
 
 vi.mock("./api", () => ({
   fetchJobByTrack: vi.fn(),
+  searchYoutube: vi.fn(),
   startYoutubeAnalysis: vi.fn(),
 }));
 
@@ -55,6 +60,51 @@ function createDeps(): SearchDeps {
     updateVizVisibility: vi.fn(),
     onTrackChange: vi.fn(),
   };
+}
+
+type FakeElement = {
+  tagName: string;
+  className: string;
+  textContent: string;
+  dataset: Record<string, string>;
+  children: FakeElement[];
+  append: (...children: FakeElement[]) => void;
+  appendChild: (child: FakeElement) => FakeElement;
+  replaceChildren: (...children: FakeElement[]) => void;
+  setAttribute: (name: string, value: string) => void;
+  addEventListener: (name: string, listener: EventListener) => void;
+};
+
+function createFakeElement(tagName: string): FakeElement {
+  return {
+    tagName,
+    className: "",
+    textContent: "",
+    dataset: {},
+    children: [],
+    append(...children: FakeElement[]) {
+      this.children.push(...children);
+    },
+    appendChild(child: FakeElement) {
+      this.children.push(child);
+      return child;
+    },
+    replaceChildren(...children: FakeElement[]) {
+      this.children = children;
+    },
+    setAttribute() {},
+    addEventListener() {},
+  };
+}
+
+function findByClass(element: FakeElement, className: string): FakeElement[] {
+  const matches = element.className.split(/\s+/).includes(className)
+    ? [element]
+    : [];
+  for (const child of element.children) {
+    matches.push(...findByClass(child, className));
+  }
+  return matches;
 }
 
 describe("search flows", () => {
@@ -169,5 +219,26 @@ describe("search flows", () => {
     });
     expect(deps.updateTrackUrl).toHaveBeenCalledWith("yt2");
     expect(deps.pollAnalysis).toHaveBeenCalledWith("job2");
+  });
+
+  it("renders youtube matches without playlist add controls", async () => {
+    vi.stubGlobal("document", {
+      createElement: vi.fn((tagName: string) => createFakeElement(tagName)),
+    });
+    const context = createContext();
+    const searchResults = createFakeElement("div");
+    context.elements.searchResults =
+      searchResults as unknown as AppContext["elements"]["searchResults"];
+    context.elements.searchHint =
+      createFakeElement("div") as unknown as AppContext["elements"]["searchHint"];
+    const deps = createDeps();
+    (api.searchYoutube as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: "yt-match", title: "Match", duration: 123 },
+    ]);
+
+    await showYoutubeMatches(context, deps, "Song", "Artist", 123);
+
+    expect(findByClass(searchResults, "playlist-add-button")).toEqual([]);
+    expect(findByClass(searchResults, "search-open")).toHaveLength(1);
   });
 });

--- a/web/src/app/search.test.ts
+++ b/web/src/app/search.test.ts
@@ -209,9 +209,14 @@ describe("search flows", () => {
 
   it("starts youtube analysis flow", async () => {
     const context = createContext();
+    context.state.tuningParams = "jb=1";
     const deps = createDeps();
+    deps.onNormalTrackSelected = vi.fn();
     (api.startYoutubeAnalysis as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "job2", status: "queued" });
     await startYoutubeAnalysisFlow(context, deps, "yt2", "Song", "Artist");
+    expect(deps.onNormalTrackSelected).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "yt2", tuningParams: "jb=1" }),
+    );
     expect(api.startYoutubeAnalysis).toHaveBeenCalledWith({
       youtube_id: "yt2",
       title: "Song",

--- a/web/src/app/search.ts
+++ b/web/src/app/search.ts
@@ -10,6 +10,7 @@ import {
   type YoutubeSearchItem,
 } from "./api";
 import type { ToastOptions } from "./ui";
+import type { PlaylistTrack } from "./playlist";
 import { tryLoadCachedAudio } from "./playback";
 import {
   isAnalysisComplete,
@@ -34,6 +35,7 @@ export type SearchDeps = {
   resetForNewTrack: (options?: { clearTuning?: boolean }) => void;
   updateVizVisibility: () => void;
   onTrackChange?: (trackId: string | null) => void;
+  onNormalTrackSelected?: (track: PlaylistTrack) => void;
 };
 
 function formatMinutes(value: number): string {
@@ -162,6 +164,14 @@ export async function startYoutubeAnalysisFlow(
   title: string,
   artist: string
 ) {
+  deps.onNormalTrackSelected?.({
+    id: youtubeId,
+    sourceType: "youtube",
+    title,
+    artist,
+    duration: null,
+    tuningParams: null,
+  });
   deps.resetForNewTrack({ clearTuning: true });
   resetSearchUI(context);
   context.state.audioLoaded = false;
@@ -246,6 +256,22 @@ export async function tryLoadExistingTrackByName(
     if (!trackId) {
       return false;
     }
+    const sourceType =
+      response.source_provider === "soundcloud" ||
+      response.source_provider === "bandcamp" ||
+      response.source_provider === "upload"
+        ? response.source_provider
+        : "youtube";
+    const playlistId =
+      response.source_id && sourceType !== "upload" ? response.source_id : trackId;
+    deps.onNormalTrackSelected?.({
+      id: playlistId,
+      sourceType,
+      title,
+      artist,
+      duration: null,
+      tuningParams: state.playMode === "jukebox" ? state.tuningParams : null,
+    });
     deps.resetForNewTrack({ clearTuning: true });
     resetSearchUI(context);
     state.audioLoaded = false;

--- a/web/src/app/search.ts
+++ b/web/src/app/search.ts
@@ -170,7 +170,8 @@ export async function startYoutubeAnalysisFlow(
     title,
     artist,
     duration: null,
-    tuningParams: null,
+    tuningParams:
+      context.state.playMode === "jukebox" ? context.state.tuningParams : null,
   });
   deps.resetForNewTrack({ clearTuning: true });
   resetSearchUI(context);

--- a/web/src/app/themeConfig.ts
+++ b/web/src/app/themeConfig.ts
@@ -10,6 +10,13 @@ export const themeConfig: Record<ThemeName, Record<string, string>> = {
     "--accent": "#4AC7FF",
     "--title-accent": "#F1C47A",
     "--title-glow": "rgba(241, 196, 122, 0.55)",
+    "--scrim": "rgba(10, 12, 16, 0.75)",
+    "--shadow-elevated": "rgba(0, 0, 0, 0.35)",
+    "--shadow-soft": "rgba(0, 0, 0, 0.24)",
+    "--danger": "#E35A5A",
+    "--danger-border": "#7F1D1D",
+    "--danger-surface": "#3B1212",
+    "--danger-text": "#FECACA",
 
     // Surfaces
     "--surface-panel": "#141922",
@@ -42,6 +49,13 @@ export const themeConfig: Record<ThemeName, Record<string, string>> = {
     "--accent": "#2E8BFF",
     "--title-accent": "#B144FF",
     "--title-glow": "rgba(177, 68, 255, 0.34)",
+    "--scrim": "rgba(38, 26, 56, 0.42)",
+    "--shadow-elevated": "rgba(38, 26, 56, 0.22)",
+    "--shadow-soft": "rgba(38, 26, 56, 0.16)",
+    "--danger": "#B3261E",
+    "--danger-border": "rgba(179, 38, 30, 0.36)",
+    "--danger-surface": "#FCEEEE",
+    "--danger-text": "#7A1B16",
 
     // Surfaces
     "--surface-panel": "#FCFAFF",

--- a/web/src/app/ui.test.ts
+++ b/web/src/app/ui.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppContext } from "./context";
 import {
+  blurMouseActivatedControl,
   isEditableTarget,
   setAnalysisStatus,
   setLoadingProgress,
@@ -46,6 +47,7 @@ class MockElement {
     public tagName: string,
     public isContentEditable = false,
   ) {}
+  blur() {}
   addEventListener() {}
   dispatchEvent() {
     return true;
@@ -86,6 +88,28 @@ describe("ui helpers", () => {
     expect(isEditableTarget(new MockElement("DIV"))).toBe(false);
     expect(isEditableTarget(new MockElement("INPUT"))).toBe(true);
     expect(isEditableTarget(new MockElement("SPAN", true))).toBe(true);
+  });
+
+  it("blurs mouse-activated controls", () => {
+    const target = new MockElement("BUTTON");
+    target.blur = vi.fn();
+    blurMouseActivatedControl({
+      currentTarget: target,
+      detail: 1,
+    } as unknown as Event);
+
+    expect(target.blur).toHaveBeenCalledOnce();
+  });
+
+  it("keeps focus for keyboard-activated controls", () => {
+    const target = new MockElement("BUTTON");
+    target.blur = vi.fn();
+    blurMouseActivatedControl({
+      currentTarget: target,
+      detail: 0,
+    } as unknown as Event);
+
+    expect(target.blur).not.toHaveBeenCalled();
   });
 
   it("shows and hides toast", () => {

--- a/web/src/app/ui.ts
+++ b/web/src/app/ui.ts
@@ -50,6 +50,15 @@ export function isEditableTarget(target: EventTarget | null): boolean {
   );
 }
 
+export function blurMouseActivatedControl(event: Event) {
+  const detail =
+    "detail" in event && typeof event.detail === "number" ? event.detail : 0;
+  if (detail <= 0 || !(event.currentTarget instanceof HTMLElement)) {
+    return;
+  }
+  event.currentTarget.blur();
+}
+
 export function showToast(
   context: AppContext,
   message: string,

--- a/web/src/app/wire/favorites.ts
+++ b/web/src/app/wire/favorites.ts
@@ -8,8 +8,9 @@ import {
   type FavoritesDisplaySort,
 } from "../favorites";
 import type { AnalysisComplete } from "../api";
-import type { ToastOptions } from "../ui";
+import { blurMouseActivatedControl, type ToastOptions } from "../ui";
 import { urlForTrack } from "../tabs";
+import type { PlaylistTrack } from "../playlist";
 
 type FavoritesDeps = {
   context: AppContext;
@@ -38,11 +39,18 @@ type FavoritesDeps = {
     tabId: TabId,
     options?: { replace?: boolean; trackId?: string | null },
   ) => void;
-  loadTrackById: (trackId: string) => void;
-  loadTrackByJobId: (jobId: string) => void;
+  loadTrackById: (
+    trackId: string,
+    options?: { selectedTrack?: PlaylistTrack | null },
+  ) => void;
+  loadTrackByJobId: (
+    jobId: string,
+    options?: { selectedTrack?: PlaylistTrack | null },
+  ) => void;
   writeTuningParamsToUrl: (tuningParams: string | null, replace?: boolean) => void;
   syncTuningParamsState: (context: AppContext) => string | null;
   setPlayMode: (mode: "jukebox" | "autocanonizer") => void;
+  onAddToPlaylist?: (track: PlaylistTrack) => void;
 };
 
 export type FavoritesHandlers = ReturnType<typeof createFavoritesHandlers>;
@@ -69,6 +77,7 @@ export function createFavoritesHandlers(deps: FavoritesDeps) {
     writeTuningParamsToUrl,
     syncTuningParamsState,
     setPlayMode,
+    onAddToPlaylist,
   } = deps;
 
   type FavoritesDelta = {
@@ -620,6 +629,7 @@ export function createFavoritesHandlers(deps: FavoritesDeps) {
 
       const removeCell = document.createElement("td");
       removeCell.className = "favorite-remove-cell";
+      const playlistButton = createFavoritePlaylistButton(item);
       const removeButton = document.createElement("button");
       removeButton.type = "button";
       removeButton.className = "favorite-remove";
@@ -628,6 +638,9 @@ export function createFavoritesHandlers(deps: FavoritesDeps) {
         '<span class="material-symbols-outlined favorite-remove-icon" aria-hidden="true">close</span>';
       removeButton.dataset.favoriteId = item.uniqueSongId;
       removeButton.addEventListener("click", handleFavoriteRemove);
+      if (playlistButton) {
+        removeCell.append(playlistButton);
+      }
       removeCell.append(removeButton);
 
       row.append(titleCell, artistCell, removeCell);
@@ -770,11 +783,14 @@ export function createFavoritesHandlers(deps: FavoritesDeps) {
         ? sourceTypeRaw
         : "youtube";
     navigateToTabWithState("play", { trackId: favoriteId });
+    const selectedTrack = favorite
+      ? favoriteToPlaylistTrack(favorite, sourceType)
+      : null;
     if (sourceType === "upload" || isLikelyJobId(favoriteId)) {
-      loadTrackByJobId(favoriteId);
+      loadTrackByJobId(favoriteId, { selectedTrack });
       return;
     }
-    loadTrackById(favoriteId);
+    loadTrackById(favoriteId, { selectedTrack });
   }
 
   function handleFavoriteRowClick(event: Event) {
@@ -803,6 +819,44 @@ export function createFavoritesHandlers(deps: FavoritesDeps) {
     }
     updateFavorites(removeFavorite(state.favorites, favoriteId));
     showFavoriteToast("Removed from Favorites");
+  }
+
+  function createFavoritePlaylistButton(item: FavoriteTrack) {
+    if (!onAddToPlaylist) {
+      return null;
+    }
+    const sourceType = item.sourceType ?? "youtube";
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "playlist-add-button";
+    button.title = "Add to playlist";
+    button.setAttribute(
+      "aria-label",
+      `Add ${item.title || "track"} to playlist`,
+    );
+    button.innerHTML =
+      '<span class="material-symbols-outlined playlist-add-icon" aria-hidden="true">add_circle</span>';
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onAddToPlaylist(favoriteToPlaylistTrack(item, sourceType));
+      blurMouseActivatedControl(event);
+    });
+    return button;
+  }
+
+  function favoriteToPlaylistTrack(
+    item: FavoriteTrack,
+    sourceType: FavoriteTrack["sourceType"],
+  ): PlaylistTrack {
+    return {
+      id: item.uniqueSongId,
+      sourceType,
+      title: item.title || "Untitled",
+      artist: item.artist || "",
+      duration: item.duration,
+      tuningParams: item.tuningParams ?? null,
+    };
   }
 
   async function handleFavoriteToggle() {

--- a/web/src/app/wire/playback.ts
+++ b/web/src/app/wire/playback.ts
@@ -58,6 +58,7 @@ type PlaybackUiDeps = {
   updateTrackInfo: (context: AppContext) => void;
   isEditableTarget: (target: EventTarget | null) => boolean;
   getCurrentTrackId: () => string | null;
+  advancePlaylistOnAutocanonizerEnded?: () => Promise<boolean>;
 };
 
 export type PlaybackUiHandlers = ReturnType<typeof createPlaybackUiHandlers>;
@@ -113,6 +114,7 @@ export function createPlaybackUiHandlers(deps: PlaybackUiDeps) {
     updateTrackInfo,
     isEditableTarget,
     getCurrentTrackId,
+    advancePlaylistOnAutocanonizerEnded,
   } = deps;
   let lastCowbellBeatsPlayed = 0;
 
@@ -210,9 +212,25 @@ export function createPlaybackUiHandlers(deps: PlaybackUiDeps) {
       state.lastBeatIndex = index;
     });
     autocanonizer.setOnEnded(() => {
-      if (state.isRunning) {
-        stopPlayback(context);
+      if (!state.isRunning) {
+        return;
       }
+      if (advancePlaylistOnAutocanonizerEnded) {
+        advancePlaylistOnAutocanonizerEnded()
+          .then((advanced) => {
+            if (!advanced && state.isRunning) {
+              stopPlayback(context);
+            }
+          })
+          .catch((err) => {
+            console.warn(`Playlist advance failed: ${String(err)}`);
+            if (state.isRunning) {
+              stopPlayback(context);
+            }
+          });
+        return;
+      }
+      stopPlayback(context);
     });
     autocanonizer.setOnSelect((index) => {
       if (state.playMode !== "autocanonizer") {

--- a/web/src/app/wire/playlist.test.ts
+++ b/web/src/app/wire/playlist.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppContext, AppState } from "../context";
+import { emptyPlaylist, type PlaylistTrack } from "../playlist";
+import { createPlaylistHandlers } from "./playlist";
+import { setWindowUrl } from "../__tests__/test-utils";
+
+function createClassList(initial: string[] = []) {
+  const classes = new Set(initial);
+  return {
+    add: vi.fn((token: string) => classes.add(token)),
+    remove: vi.fn((token: string) => classes.delete(token)),
+    toggle: vi.fn((token: string, force?: boolean) => {
+      if (force === true) {
+        classes.add(token);
+        return true;
+      }
+      if (force === false) {
+        classes.delete(token);
+        return false;
+      }
+      if (classes.has(token)) {
+        classes.delete(token);
+        return false;
+      }
+      classes.add(token);
+      return true;
+    }),
+    contains: vi.fn((token: string) => classes.has(token)),
+  };
+}
+
+function setLocalStorage() {
+  const store = new Map<string, string>();
+  globalThis.localStorage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  } as Storage;
+}
+
+function track(id: string, sourceType: PlaylistTrack["sourceType"] = "youtube") {
+  return {
+    id,
+    sourceType,
+    title: `Track ${id}`,
+    artist: "Artist",
+    duration: null,
+  } satisfies PlaylistTrack;
+}
+
+function createButton() {
+  return {
+    classList: createClassList(),
+    disabled: false,
+    title: "",
+    setAttribute: vi.fn(),
+  } as unknown as HTMLButtonElement;
+}
+
+function createDeps(overrides?: Partial<AppState>) {
+  const state = {
+    playlist: emptyPlaylist(),
+    lastTrackId: null,
+    lastJobId: null,
+    lastSourceProvider: null,
+    trackTitle: null,
+    trackArtist: null,
+    trackDurationSec: null,
+    playMode: "jukebox",
+    tuningParams: null,
+    audioLoaded: false,
+    analysisLoaded: false,
+    audioLoadInFlight: false,
+    pollController: null,
+    swingPreparing: false,
+    isRunning: false,
+    toastTimer: null,
+    ...overrides,
+  } as unknown as AppState;
+  const elements = {
+    playlistButton: createButton(),
+    playlistPreviousButton: createButton(),
+    playlistNextButton: createButton(),
+    savedPlaylistButton: createButton(),
+    playlistModal: {
+      classList: createClassList(),
+    },
+    playlistList: {
+      innerHTML: "",
+      textContent: "",
+    },
+    playlistClearButton: createButton(),
+  } as unknown as AppContext["elements"];
+  const context = {
+    state,
+    elements,
+  } as unknown as AppContext;
+  return {
+    context,
+    elements,
+    state,
+    showToast: vi.fn(),
+    loadTrackById: vi.fn(async () => {}),
+    loadTrackByJobId: vi.fn(async () => {}),
+    navigateToTabWithState: vi.fn(),
+    togglePlayback: vi.fn(),
+  };
+}
+
+describe("playlist handlers", () => {
+  beforeEach(() => {
+    setLocalStorage();
+    setWindowUrl("http://localhost/listen");
+  });
+
+  it("adds with current track and reports duplicate/full toasts", () => {
+    const deps = createDeps({
+      lastTrackId: "current",
+      lastSourceProvider: "youtube",
+      trackTitle: "Current",
+    } as Partial<AppState>);
+    const handlers = createPlaylistHandlers(deps);
+
+    handlers.handleAddToPlaylist(track("next"));
+    expect(deps.state.playlist.tracks.map((item) => item.id)).toEqual([
+      "current",
+      "next",
+    ]);
+
+    handlers.handleAddToPlaylist(track("next"));
+    expect(deps.showToast).toHaveBeenCalledWith(
+      deps.context,
+      "Already in playlist",
+    );
+
+    deps.state.playlist = {
+      tracks: Array.from({ length: 10 }, (_, index) => track(`${index}`)),
+      currentIndex: 0,
+    };
+    handlers.handleAddToPlaylist(track("extra"));
+    expect(deps.showToast).toHaveBeenCalledWith(
+      deps.context,
+      "Playlist is full.",
+    );
+  });
+
+  it("asks for a current track before starting a playlist", () => {
+    const deps = createDeps();
+    const handlers = createPlaylistHandlers(deps);
+
+    handlers.handleAddToPlaylist(track("next"));
+
+    expect(deps.showToast).toHaveBeenCalledWith(
+      deps.context,
+      "Load a track before starting a playlist.",
+    );
+  });
+
+  it("clears inactive saved playlists on normal track selection", () => {
+    const deps = createDeps({
+      playlist: { tracks: [track("a"), track("b")], currentIndex: -1 },
+    } as Partial<AppState>);
+    const handlers = createPlaylistHandlers(deps);
+
+    handlers.handleNormalTrackSelected(track("outside"));
+
+    expect(deps.state.playlist).toEqual(emptyPlaylist());
+  });
+
+  it("replaces the active playlist item on normal track selection", () => {
+    const deps = createDeps({
+      playlist: { tracks: [track("a"), track("b")], currentIndex: 1 },
+    } as Partial<AppState>);
+    const handlers = createPlaylistHandlers(deps);
+
+    handlers.handleNormalTrackSelected(track("outside"));
+
+    expect(deps.state.playlist.currentIndex).toBe(1);
+    expect(deps.state.playlist.tracks.map((item) => item.id)).toEqual([
+      "a",
+      "outside",
+    ]);
+  });
+
+  it("loads playlist items with playlist load options and blocks while busy", async () => {
+    const deps = createDeps({
+      playlist: { tracks: [track("a"), track("b")], currentIndex: 0 },
+    } as Partial<AppState>);
+    const handlers = createPlaylistHandlers(deps);
+
+    await handlers.loadPlaylistIndex(1);
+
+    expect(deps.loadTrackById).toHaveBeenCalledWith("b", {
+      preserveUrlTuning: true,
+      playlistLoad: true,
+      selectedTrack: track("b"),
+    });
+
+    deps.state.audioLoadInFlight = true;
+    await handlers.loadPlaylistIndex(0);
+    expect(deps.loadTrackById).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not load or close the modal for the current playlist item", async () => {
+    const deps = createDeps({
+      playlist: { tracks: [track("a"), track("b")], currentIndex: 0 },
+    } as Partial<AppState>);
+    const handlers = createPlaylistHandlers(deps);
+
+    await handlers.loadPlaylistIndex(0, { closeModal: true });
+
+    expect(deps.loadTrackById).not.toHaveBeenCalled();
+    expect(deps.elements.playlistModal.classList.remove).not.toHaveBeenCalledWith(
+      "open",
+    );
+  });
+
+  it("closes the playlist modal immediately after selecting a playlist item", async () => {
+    const deps = createDeps({
+      playlist: { tracks: [track("a"), track("b")], currentIndex: 0 },
+    } as Partial<AppState>);
+    let resolveLoad: () => void = () => {};
+    deps.loadTrackById = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLoad = resolve;
+        }),
+    );
+    const handlers = createPlaylistHandlers(deps);
+
+    const loadPromise = handlers.loadPlaylistIndex(1, { closeModal: true });
+
+    expect(deps.elements.playlistModal.classList.remove).toHaveBeenCalledWith(
+      "open",
+    );
+
+    resolveLoad();
+    await loadPromise;
+  });
+
+  it("advances autocanonizer to the next playlist track when available", async () => {
+    const deps = createDeps({
+      playlist: { tracks: [track("a"), track("b")], currentIndex: 0 },
+    } as Partial<AppState>);
+    const handlers = createPlaylistHandlers(deps);
+
+    const advanced = await handlers.advanceAutocanonizerOnEnded();
+
+    expect(advanced).toBe(true);
+    expect(deps.loadTrackById).toHaveBeenCalledOnce();
+    expect(deps.togglePlayback).toHaveBeenCalledWith(deps.context);
+  });
+
+  it("does not advance autocanonizer without a next playlist track", async () => {
+    const deps = createDeps({
+      playlist: { tracks: [track("a"), track("b")], currentIndex: 1 },
+    } as Partial<AppState>);
+    const handlers = createPlaylistHandlers(deps);
+
+    await expect(handlers.advanceAutocanonizerOnEnded()).resolves.toBe(false);
+    expect(deps.loadTrackById).not.toHaveBeenCalled();
+  });
+
+  it("clears the playlist from the modal action", () => {
+    const deps = createDeps({
+      playlist: { tracks: [track("a"), track("b")], currentIndex: 0 },
+    } as Partial<AppState>);
+    const handlers = createPlaylistHandlers(deps);
+
+    handlers.handleClearPlaylist();
+
+    expect(deps.state.playlist).toEqual(emptyPlaylist());
+    expect(deps.elements.playlistModal.classList.remove).toHaveBeenCalledWith(
+      "open",
+    );
+  });
+});

--- a/web/src/app/wire/playlist.test.ts
+++ b/web/src/app/wire/playlist.test.ts
@@ -107,8 +107,8 @@ function createDeps(overrides?: Partial<AppState>) {
     elements,
     state,
     showToast: vi.fn(),
-    loadTrackById: vi.fn(async () => {}),
-    loadTrackByJobId: vi.fn(async () => {}),
+    loadTrackById: vi.fn(async () => true),
+    loadTrackByJobId: vi.fn(async () => true),
     navigateToTabWithState: vi.fn(),
     togglePlayback: vi.fn(),
   };
@@ -163,6 +163,55 @@ describe("playlist handlers", () => {
     );
   });
 
+  it("uses the job id as an upload when adding the current uploaded track", () => {
+    const jobId = "a3f3c0dc73c6476c9db95c227f9206f2";
+    const deps = createDeps({
+      lastTrackId: null,
+      lastJobId: jobId,
+      trackTitle: "Upload",
+    } as Partial<AppState>);
+    const handlers = createPlaylistHandlers(deps);
+
+    handlers.handleAddToPlaylist(track("next"));
+
+    expect(deps.state.playlist.tracks[0]).toMatchObject({
+      id: jobId,
+      sourceType: "upload",
+    });
+  });
+
+  it("uses provider source ids when adding the current provider track", () => {
+    const deps = createDeps({
+      lastTrackId: "soundcloud:source-1",
+      lastSourceProvider: "soundcloud",
+      trackTitle: "Provider Track",
+    } as Partial<AppState>);
+    const handlers = createPlaylistHandlers(deps);
+
+    handlers.handleAddToPlaylist(track("next"));
+
+    expect(deps.state.playlist.tracks[0]).toMatchObject({
+      id: "source-1",
+      sourceType: "soundcloud",
+    });
+  });
+
+  it("shows an invalid message for malformed playlist tracks", () => {
+    const deps = createDeps({
+      lastTrackId: "current",
+      lastSourceProvider: "youtube",
+      trackTitle: "Current",
+    } as Partial<AppState>);
+    const handlers = createPlaylistHandlers(deps);
+
+    handlers.handleAddToPlaylist({ ...track(""), id: "" });
+
+    expect(deps.showToast).toHaveBeenCalledWith(
+      deps.context,
+      "Track cannot be added to playlist.",
+    );
+  });
+
   it("clears inactive saved playlists on normal track selection", () => {
     const deps = createDeps({
       playlist: { tracks: [track("a"), track("b")], currentIndex: -1 },
@@ -208,6 +257,42 @@ describe("playlist handlers", () => {
     expect(deps.loadTrackById).toHaveBeenCalledTimes(1);
   });
 
+  it("rolls back playlist activation when a playlist item load fails", async () => {
+    const deps = createDeps({
+      playlist: { tracks: [track("a"), track("b")], currentIndex: 0 },
+      isRunning: false,
+    } as Partial<AppState>);
+    deps.loadTrackById = vi.fn(async (): Promise<boolean> => false);
+    const handlers = createPlaylistHandlers(deps);
+
+    const loaded = await handlers.loadPlaylistIndex(1, { playAfterLoad: true });
+
+    expect(loaded).toBe(false);
+    expect(deps.state.playlist.currentIndex).toBe(0);
+    expect(deps.togglePlayback).not.toHaveBeenCalled();
+  });
+
+  it("blocks rapid playlist skips while a playlist load is pending", () => {
+    const deps = createDeps({
+      playlist: {
+        tracks: [track("a"), track("b"), track("c")],
+        currentIndex: 0,
+      },
+    } as Partial<AppState>);
+    deps.loadTrackById = vi.fn(
+      () =>
+        new Promise<boolean>(() => {
+          // Keep the first load pending.
+        }),
+    );
+    const handlers = createPlaylistHandlers(deps);
+
+    handlers.handlePlaylistNext();
+    handlers.handlePlaylistNext();
+
+    expect(deps.loadTrackById).toHaveBeenCalledTimes(1);
+  });
+
   it("does not load or close the modal for the current playlist item", async () => {
     const deps = createDeps({
       playlist: { tracks: [track("a"), track("b")], currentIndex: 0 },
@@ -226,10 +311,10 @@ describe("playlist handlers", () => {
     const deps = createDeps({
       playlist: { tracks: [track("a"), track("b")], currentIndex: 0 },
     } as Partial<AppState>);
-    let resolveLoad: () => void = () => {};
+    let resolveLoad: (value: boolean) => void = () => {};
     deps.loadTrackById = vi.fn(
       () =>
-        new Promise<void>((resolve) => {
+        new Promise<boolean>((resolve) => {
           resolveLoad = resolve;
         }),
     );
@@ -241,7 +326,7 @@ describe("playlist handlers", () => {
       "open",
     );
 
-    resolveLoad();
+    resolveLoad(true);
     await loadPromise;
   });
 
@@ -256,6 +341,31 @@ describe("playlist handlers", () => {
     expect(advanced).toBe(true);
     expect(deps.loadTrackById).toHaveBeenCalledOnce();
     expect(deps.togglePlayback).toHaveBeenCalledWith(deps.context);
+  });
+
+  it("does not report autocanonizer advance when the playlist load fails", async () => {
+    const deps = createDeps({
+      playlist: { tracks: [track("a"), track("b")], currentIndex: 0 },
+    } as Partial<AppState>);
+    deps.loadTrackById = vi.fn(async (): Promise<boolean> => false);
+    const handlers = createPlaylistHandlers(deps);
+
+    const advanced = await handlers.advanceAutocanonizerOnEnded();
+
+    expect(advanced).toBe(false);
+    expect(deps.togglePlayback).not.toHaveBeenCalled();
+  });
+
+  it("closes the playlist modal with Escape", () => {
+    const deps = createDeps();
+    deps.elements.playlistModal.classList.add("open");
+    const handlers = createPlaylistHandlers(deps);
+
+    handlers.handlePlaylistModalKeydown({ key: "Escape" } as KeyboardEvent);
+
+    expect(deps.elements.playlistModal.classList.remove).toHaveBeenCalledWith(
+      "open",
+    );
   });
 
   it("does not advance autocanonizer without a next playlist track", async () => {

--- a/web/src/app/wire/playlist.ts
+++ b/web/src/app/wire/playlist.ts
@@ -34,7 +34,7 @@ type PlaylistDeps = {
       playlistLoad?: boolean;
       selectedTrack?: PlaylistTrack | null;
     },
-  ) => Promise<void>;
+  ) => Promise<boolean | void>;
   loadTrackByJobId: (
     jobId: string,
     options?: {
@@ -42,7 +42,7 @@ type PlaylistDeps = {
       playlistLoad?: boolean;
       selectedTrack?: PlaylistTrack | null;
     },
-  ) => Promise<void>;
+  ) => Promise<boolean | void>;
   navigateToTabWithState: (
     tabId: TabId,
     options?: { replace?: boolean; trackId?: string | null },
@@ -63,13 +63,14 @@ export function createPlaylistHandlers(deps: PlaylistDeps) {
     navigateToTabWithState,
     togglePlayback,
   } = deps;
+  let playlistLoadInFlight = false;
 
   function getCurrentPlaylistTrack(): PlaylistTrack | null {
-    const id = state.lastTrackId ?? state.lastJobId;
+    const id = getCurrentPlaylistTrackId();
     if (!id) {
       return null;
     }
-    const sourceType = getCurrentPlaylistSourceType();
+    const sourceType = getCurrentPlaylistSourceType(id);
     const tuningParams = getCurrentTuningParams();
     return {
       id,
@@ -81,7 +82,27 @@ export function createPlaylistHandlers(deps: PlaylistDeps) {
     };
   }
 
-  function getCurrentPlaylistSourceType(): PlaylistTrack["sourceType"] {
+  function getCurrentPlaylistTrackId() {
+    const rawId = state.lastTrackId ?? state.lastJobId;
+    if (!rawId) {
+      return null;
+    }
+    const provider = state.lastSourceProvider;
+    if ((provider === "soundcloud" || provider === "bandcamp") && state.lastTrackId) {
+      const prefix = `${provider}:`;
+      return state.lastTrackId.startsWith(prefix)
+        ? state.lastTrackId.slice(prefix.length)
+        : state.lastTrackId;
+    }
+    if (provider === "upload") {
+      return state.lastJobId ?? rawId;
+    }
+    return rawId;
+  }
+
+  function getCurrentPlaylistSourceType(
+    id: string,
+  ): PlaylistTrack["sourceType"] {
     const provider = state.lastSourceProvider;
     if (
       provider === "youtube" ||
@@ -91,7 +112,7 @@ export function createPlaylistHandlers(deps: PlaylistDeps) {
     ) {
       return provider;
     }
-    return isLikelyJobId(state.lastTrackId ?? "") ? "upload" : "youtube";
+    return isLikelyJobId(id) ? "upload" : "youtube";
   }
 
   function handleNormalTrackSelected(track: PlaylistTrack) {
@@ -122,6 +143,10 @@ export function createPlaylistHandlers(deps: PlaylistDeps) {
       showToast(context, "Playlist is full.");
       return;
     }
+    if (result.status === "invalid") {
+      showToast(context, "Track cannot be added to playlist.");
+      return;
+    }
     updatePlaylist(result.playlist);
     showToast(context, "Added to playlist", { icon: "playlist_add_check" });
   }
@@ -137,6 +162,15 @@ export function createPlaylistHandlers(deps: PlaylistDeps) {
 
   function handlePlaylistModalClick(event: MouseEvent) {
     if (event.target === elements.playlistModal) {
+      handleClosePlaylist();
+    }
+  }
+
+  function handlePlaylistModalKeydown(event: KeyboardEvent) {
+    if (
+      event.key === "Escape" &&
+      elements.playlistModal.classList.contains("open")
+    ) {
       handleClosePlaylist();
     }
   }
@@ -172,44 +206,57 @@ export function createPlaylistHandlers(deps: PlaylistDeps) {
     if (!canMovePlaylistNext(state.playlist) || isPlaylistLoadBlocked()) {
       return false;
     }
-    await loadPlaylistIndex(state.playlist.currentIndex + 1, {
+    return await loadPlaylistIndex(state.playlist.currentIndex + 1, {
       playAfterLoad: true,
     });
-    return true;
   }
 
   async function loadPlaylistIndex(
     index: number,
     options?: { playAfterLoad?: boolean; closeModal?: boolean },
-  ) {
+  ): Promise<boolean> {
     const track = state.playlist.tracks[index];
     if (index === state.playlist.currentIndex || !track || isPlaylistLoadBlocked()) {
       syncPlaylistUi();
-      return;
+      return false;
     }
     if (options?.closeModal) {
       handleClosePlaylist();
     }
+    const previousPlaylist = state.playlist;
+    playlistLoadInFlight = true;
     updatePlaylist(activatePlaylistTrack(state.playlist, index));
     applyTrackTuning(track);
     navigateToTabWithState("play", { trackId: getPlaylistListenId(track) });
-    if (track.sourceType === "upload" || isLikelyJobId(track.id)) {
-      await loadTrackByJobId(track.id, {
-        preserveUrlTuning: true,
-        playlistLoad: true,
-        selectedTrack: track,
-      });
-    } else {
-      await loadTrackById(getPlaylistLoadId(track), {
-        preserveUrlTuning: true,
-        playlistLoad: true,
-        selectedTrack: track,
-      });
+    let loadStarted = false;
+    try {
+      const result =
+        track.sourceType === "upload" || isLikelyJobId(track.id)
+          ? await loadTrackByJobId(track.id, {
+              preserveUrlTuning: true,
+              playlistLoad: true,
+              selectedTrack: track,
+            })
+          : await loadTrackById(getPlaylistLoadId(track), {
+              preserveUrlTuning: true,
+              playlistLoad: true,
+              selectedTrack: track,
+            });
+      loadStarted = result !== false;
+    } catch {
+      loadStarted = false;
+    } finally {
+      playlistLoadInFlight = false;
+    }
+    if (!loadStarted) {
+      updatePlaylist(previousPlaylist);
+      return false;
     }
     syncPlaylistUi();
     if (options?.playAfterLoad && !state.isRunning) {
       togglePlayback(context);
     }
+    return true;
   }
 
   function renderPlaylistModal() {
@@ -340,6 +387,7 @@ export function createPlaylistHandlers(deps: PlaylistDeps) {
     return (
       state.audioLoadInFlight ||
       state.pollController !== null ||
+      playlistLoadInFlight ||
       state.swingPreparing
     );
   }
@@ -385,6 +433,7 @@ export function createPlaylistHandlers(deps: PlaylistDeps) {
     handleOpenPlaylist,
     handleClosePlaylist,
     handlePlaylistModalClick,
+    handlePlaylistModalKeydown,
     handleClearPlaylist,
     handleSavedPlaylistClick,
     handlePlaylistPrevious,

--- a/web/src/app/wire/playlist.ts
+++ b/web/src/app/wire/playlist.ts
@@ -1,0 +1,396 @@
+import type { AppContext, AppState, TabId } from "../context";
+import type { Elements } from "../elements";
+import {
+  activatePlaylistTrack,
+  addPlaylistTrack,
+  canMovePlaylistNext,
+  canMovePlaylistPrevious,
+  emptyPlaylist,
+  hasActivePlaylistControls,
+  hasInactiveSavedPlaylist,
+  hasPlaylistControls,
+  isPlaylistActive,
+  removePlaylistTrack,
+  replaceActivePlaylistTrack,
+  savePlaylist,
+  type PlaylistTrack,
+} from "../playlist";
+import { syncTuningParamsState, writeTuningParamsToUrl } from "../tuning";
+import type { ToastOptions } from "../ui";
+
+type PlaylistDeps = {
+  context: AppContext;
+  elements: Elements;
+  state: AppState;
+  showToast: (
+    context: AppContext,
+    message: string,
+    options?: ToastOptions,
+  ) => void;
+  loadTrackById: (
+    trackId: string,
+    options?: {
+      preserveUrlTuning?: boolean;
+      playlistLoad?: boolean;
+      selectedTrack?: PlaylistTrack | null;
+    },
+  ) => Promise<void>;
+  loadTrackByJobId: (
+    jobId: string,
+    options?: {
+      preserveUrlTuning?: boolean;
+      playlistLoad?: boolean;
+      selectedTrack?: PlaylistTrack | null;
+    },
+  ) => Promise<void>;
+  navigateToTabWithState: (
+    tabId: TabId,
+    options?: { replace?: boolean; trackId?: string | null },
+  ) => void;
+  togglePlayback: (context: AppContext) => void;
+};
+
+export type PlaylistHandlers = ReturnType<typeof createPlaylistHandlers>;
+
+export function createPlaylistHandlers(deps: PlaylistDeps) {
+  const {
+    context,
+    elements,
+    state,
+    showToast,
+    loadTrackById,
+    loadTrackByJobId,
+    navigateToTabWithState,
+    togglePlayback,
+  } = deps;
+
+  function getCurrentPlaylistTrack(): PlaylistTrack | null {
+    const id = state.lastTrackId ?? state.lastJobId;
+    if (!id) {
+      return null;
+    }
+    const sourceType = getCurrentPlaylistSourceType();
+    const tuningParams = getCurrentTuningParams();
+    return {
+      id,
+      sourceType,
+      title: state.trackTitle || "Untitled",
+      artist: state.trackArtist || "",
+      duration: state.trackDurationSec,
+      tuningParams,
+    };
+  }
+
+  function getCurrentPlaylistSourceType(): PlaylistTrack["sourceType"] {
+    const provider = state.lastSourceProvider;
+    if (
+      provider === "youtube" ||
+      provider === "soundcloud" ||
+      provider === "bandcamp" ||
+      provider === "upload"
+    ) {
+      return provider;
+    }
+    return isLikelyJobId(state.lastTrackId ?? "") ? "upload" : "youtube";
+  }
+
+  function handleNormalTrackSelected(track: PlaylistTrack) {
+    if (isPlaylistActive(state.playlist)) {
+      updatePlaylist(replaceActivePlaylistTrack(state.playlist, track));
+      return;
+    }
+    if (hasInactiveSavedPlaylist(state.playlist)) {
+      updatePlaylist(emptyPlaylist());
+    }
+  }
+
+  function handleAddToPlaylist(track: PlaylistTrack) {
+    const result = addPlaylistTrack(
+      state.playlist,
+      getCurrentPlaylistTrack(),
+      track,
+    );
+    if (result.status === "no-current") {
+      showToast(context, "Load a track before starting a playlist.");
+      return;
+    }
+    if (result.status === "duplicate") {
+      showToast(context, "Already in playlist");
+      return;
+    }
+    if (result.status === "full") {
+      showToast(context, "Playlist is full.");
+      return;
+    }
+    updatePlaylist(result.playlist);
+    showToast(context, "Added to playlist", { icon: "playlist_add_check" });
+  }
+
+  function handleOpenPlaylist() {
+    renderPlaylistModal();
+    elements.playlistModal.classList.add("open");
+  }
+
+  function handleClosePlaylist() {
+    elements.playlistModal.classList.remove("open");
+  }
+
+  function handlePlaylistModalClick(event: MouseEvent) {
+    if (event.target === elements.playlistModal) {
+      handleClosePlaylist();
+    }
+  }
+
+  function handleClearPlaylist() {
+    updatePlaylist(emptyPlaylist());
+    handleClosePlaylist();
+  }
+
+  function handleSavedPlaylistClick() {
+    handleOpenPlaylist();
+  }
+
+  function handlePlaylistPrevious() {
+    if (!canMovePlaylistPrevious(state.playlist) || isPlaylistLoadBlocked()) {
+      return;
+    }
+    void loadPlaylistIndex(state.playlist.currentIndex - 1, {
+      playAfterLoad: state.isRunning,
+    });
+  }
+
+  function handlePlaylistNext() {
+    if (!canMovePlaylistNext(state.playlist) || isPlaylistLoadBlocked()) {
+      return;
+    }
+    void loadPlaylistIndex(state.playlist.currentIndex + 1, {
+      playAfterLoad: state.isRunning,
+    });
+  }
+
+  async function advanceAutocanonizerOnEnded() {
+    if (!canMovePlaylistNext(state.playlist) || isPlaylistLoadBlocked()) {
+      return false;
+    }
+    await loadPlaylistIndex(state.playlist.currentIndex + 1, {
+      playAfterLoad: true,
+    });
+    return true;
+  }
+
+  async function loadPlaylistIndex(
+    index: number,
+    options?: { playAfterLoad?: boolean; closeModal?: boolean },
+  ) {
+    const track = state.playlist.tracks[index];
+    if (index === state.playlist.currentIndex || !track || isPlaylistLoadBlocked()) {
+      syncPlaylistUi();
+      return;
+    }
+    if (options?.closeModal) {
+      handleClosePlaylist();
+    }
+    updatePlaylist(activatePlaylistTrack(state.playlist, index));
+    applyTrackTuning(track);
+    navigateToTabWithState("play", { trackId: getPlaylistListenId(track) });
+    if (track.sourceType === "upload" || isLikelyJobId(track.id)) {
+      await loadTrackByJobId(track.id, {
+        preserveUrlTuning: true,
+        playlistLoad: true,
+        selectedTrack: track,
+      });
+    } else {
+      await loadTrackById(getPlaylistLoadId(track), {
+        preserveUrlTuning: true,
+        playlistLoad: true,
+        selectedTrack: track,
+      });
+    }
+    syncPlaylistUi();
+    if (options?.playAfterLoad && !state.isRunning) {
+      togglePlayback(context);
+    }
+  }
+
+  function renderPlaylistModal() {
+    elements.playlistList.innerHTML = "";
+    if (state.playlist.tracks.length === 0) {
+      elements.playlistList.textContent = "No playlist yet.";
+      elements.playlistClearButton.disabled = true;
+      return;
+    }
+    elements.playlistClearButton.disabled = false;
+    const list = document.createElement("ol");
+    list.className = "playlist-list";
+    state.playlist.tracks.forEach((track, index) => {
+      const isCurrent = index === state.playlist.currentIndex;
+      const item = document.createElement("li");
+      item.className = "playlist-item";
+      item.classList.toggle("is-current", isCurrent);
+      const selectButton = document.createElement("button");
+      selectButton.type = "button";
+      selectButton.className = "playlist-select";
+      selectButton.dataset.playlistIndex = String(index);
+      selectButton.disabled = isCurrent;
+      selectButton.addEventListener("click", handlePlaylistItemClick);
+      const title = document.createElement("span");
+      title.className = "playlist-item-title";
+      title.textContent = track.title || "Untitled";
+      const artist = document.createElement("span");
+      artist.className = "playlist-item-artist";
+      artist.textContent = track.artist || "";
+      selectButton.append(title, artist);
+
+      const removeButton = document.createElement("button");
+      removeButton.type = "button";
+      removeButton.className = "playlist-remove";
+      removeButton.dataset.playlistIndex = String(index);
+      removeButton.disabled = isCurrent;
+      removeButton.setAttribute("aria-label", `Remove ${track.title || "track"}`);
+      removeButton.innerHTML =
+        '<span class="material-symbols-outlined playlist-remove-icon" aria-hidden="true">close</span>';
+      removeButton.addEventListener("click", handlePlaylistRemoveClick);
+      item.append(selectButton, removeButton);
+      list.append(item);
+    });
+    elements.playlistList.append(list);
+  }
+
+  function handlePlaylistItemClick(event: Event) {
+    const button = event.currentTarget as HTMLButtonElement | null;
+    const index = Number(button?.dataset.playlistIndex);
+    if (!Number.isInteger(index)) {
+      return;
+    }
+    if (
+      index === state.playlist.currentIndex ||
+      !state.playlist.tracks[index] ||
+      isPlaylistLoadBlocked()
+    ) {
+      syncPlaylistUi();
+      return;
+    }
+    void loadPlaylistIndex(index, { closeModal: true });
+  }
+
+  function handlePlaylistRemoveClick(event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const button = event.currentTarget as HTMLButtonElement | null;
+    const index = Number(button?.dataset.playlistIndex);
+    if (!Number.isInteger(index)) {
+      return;
+    }
+    updatePlaylist(removePlaylistTrack(state.playlist, index));
+  }
+
+  function syncPlaylistUi() {
+    const hasTracks = hasPlaylistControls(state.playlist);
+    const active = hasActivePlaylistControls(state.playlist);
+    const busy = isPlaylistLoadBlocked();
+    if (typeof document !== "undefined") {
+      document.body.classList.toggle("playlist-add-enabled", hasLoadedTrack());
+    }
+    elements.playlistButton.classList.toggle("is-hidden", !hasTracks);
+    elements.playlistPreviousButton.classList.toggle("is-hidden", !active);
+    elements.playlistNextButton.classList.toggle("is-hidden", !active);
+    elements.playlistPreviousButton.disabled =
+      busy || !canMovePlaylistPrevious(state.playlist);
+    elements.playlistNextButton.disabled =
+      busy || !canMovePlaylistNext(state.playlist);
+    elements.playlistButton.title = active
+      ? `Playlist (${state.playlist.currentIndex + 1}/${state.playlist.tracks.length})`
+      : "Saved Playlist";
+    elements.playlistButton.setAttribute("aria-label", elements.playlistButton.title);
+    elements.savedPlaylistButton.classList.toggle(
+      "hidden",
+      !shouldShowSavedPlaylistButton(),
+    );
+    if (elements.playlistModal.classList.contains("open")) {
+      renderPlaylistModal();
+    }
+  }
+
+  function updatePlaylist(nextPlaylist: AppState["playlist"]) {
+    state.playlist = nextPlaylist;
+    savePlaylist(nextPlaylist);
+    syncPlaylistUi();
+  }
+
+  function shouldShowSavedPlaylistButton() {
+    return (
+      hasInactiveSavedPlaylist(state.playlist) &&
+      !state.audioLoaded &&
+      !state.analysisLoaded &&
+      !state.audioLoadInFlight &&
+      !state.lastTrackId &&
+      !state.lastJobId
+    );
+  }
+
+  function hasLoadedTrack() {
+    return (
+      Boolean(state.lastTrackId ?? state.lastJobId) &&
+      state.audioLoaded &&
+      state.analysisLoaded
+    );
+  }
+
+  function isPlaylistLoadBlocked() {
+    return (
+      state.audioLoadInFlight ||
+      state.pollController !== null ||
+      state.swingPreparing
+    );
+  }
+
+  function applyTrackTuning(track: PlaylistTrack) {
+    state.tuningParams = state.playMode === "jukebox"
+      ? (track.tuningParams ?? null)
+      : null;
+    writeTuningParamsToUrl(state.tuningParams, true);
+  }
+
+  function getCurrentTuningParams() {
+    if (state.playMode !== "jukebox") {
+      return null;
+    }
+    if (!context.engine || !context.defaultConfig) {
+      return state.tuningParams;
+    }
+    return syncTuningParamsState(context);
+  }
+
+  function getPlaylistListenId(track: PlaylistTrack) {
+    if (track.sourceType === "youtube" || track.sourceType === "upload") {
+      return track.id;
+    }
+    return `${track.sourceType}:${track.id}`;
+  }
+
+  function getPlaylistLoadId(track: PlaylistTrack) {
+    if (track.sourceType === "youtube") {
+      return track.id;
+    }
+    return `${track.sourceType}:${track.id}`;
+  }
+
+  function isLikelyJobId(value: string) {
+    return /^[a-f0-9]{32}$/.test(value);
+  }
+
+  return {
+    handleNormalTrackSelected,
+    handleAddToPlaylist,
+    handleOpenPlaylist,
+    handleClosePlaylist,
+    handlePlaylistModalClick,
+    handleClearPlaylist,
+    handleSavedPlaylistClick,
+    handlePlaylistPrevious,
+    handlePlaylistNext,
+    advanceAutocanonizerOnEnded,
+    loadPlaylistIndex,
+    syncPlaylistUi,
+  };
+}

--- a/web/src/app/wire/search.test.ts
+++ b/web/src/app/wire/search.test.ts
@@ -33,6 +33,10 @@ function createHarness() {
   } as unknown as AppState;
   const showToast = vi.fn();
   const startUrlAnalysis = vi.fn();
+  const onNormalTrackSelected = vi.fn();
+  const resetForNewTrack = vi.fn();
+  const updateTrackUrl = vi.fn();
+  const pollAnalysisJob = vi.fn();
   const handlers = createSearchHandlers({
     context,
     elements,
@@ -42,13 +46,23 @@ function createHarness() {
     showToast,
     uploadAudio: vi.fn(),
     startUrlAnalysis,
-    resetForNewTrack: vi.fn(),
+    resetForNewTrack,
     setActiveTabWithRefresh: vi.fn(),
     setLoadingProgress: vi.fn(),
-    updateTrackUrl: vi.fn(),
-    pollAnalysisJob: vi.fn(),
+    updateTrackUrl,
+    pollAnalysisJob,
+    onNormalTrackSelected,
   });
-  return { elements, handlers, showToast, startUrlAnalysis };
+  return {
+    elements,
+    handlers,
+    onNormalTrackSelected,
+    pollAnalysisJob,
+    showToast,
+    startUrlAnalysis,
+    state,
+    updateTrackUrl,
+  };
 }
 
 describe("createSearchHandlers", () => {
@@ -92,5 +106,41 @@ describe("createSearchHandlers", () => {
       "Bandcamp fetch failed.",
       { icon: "error", tone: "error" },
     );
+  });
+
+  it("uses provider listen ids and source playlist ids for URL uploads", async () => {
+    const {
+      elements,
+      handlers,
+      onNormalTrackSelected,
+      pollAnalysisJob,
+      startUrlAnalysis,
+      state,
+      updateTrackUrl,
+    } = createHarness();
+    elements.uploadYoutubeInput.value = "https://soundcloud.com/artist/track";
+    startUrlAnalysis.mockResolvedValue({
+      id: "job-soundcloud",
+      status: "queued",
+      source_id: "source-soundcloud",
+      source_provider: "soundcloud",
+    });
+
+    await handlers.handleUploadYoutubeClick();
+
+    expect(onNormalTrackSelected).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "source-soundcloud",
+        sourceType: "soundcloud",
+      }),
+    );
+    expect(state.lastTrackId).toBe("soundcloud:source-soundcloud");
+    expect(updateTrackUrl).toHaveBeenCalledWith(
+      "soundcloud:source-soundcloud",
+      true,
+      null,
+      "jukebox",
+    );
+    expect(pollAnalysisJob).toHaveBeenCalledWith("job-soundcloud");
   });
 });

--- a/web/src/app/wire/search.ts
+++ b/web/src/app/wire/search.ts
@@ -2,6 +2,7 @@ import type { AppContext, AppState, TabId } from "../context";
 import type { Elements } from "../elements";
 import type { SearchDeps } from "../search";
 import type { ToastOptions } from "../ui";
+import type { PlaylistTrack } from "../playlist";
 import {
   formatErrorForDisplay,
   inferSourceProviderFromUrl,
@@ -39,6 +40,7 @@ type SearchHandlersDeps = {
     playMode?: "jukebox" | "autocanonizer",
   ) => void;
   pollAnalysisJob: (jobId: string) => Promise<void>;
+  onNormalTrackSelected?: (track: PlaylistTrack) => void;
 };
 
 export type SearchHandlers = ReturnType<typeof createSearchHandlers>;
@@ -58,6 +60,7 @@ export function createSearchHandlers(deps: SearchHandlersDeps) {
     setLoadingProgress,
     updateTrackUrl,
     pollAnalysisJob,
+    onNormalTrackSelected,
   } = deps;
   let searchInFlight = false;
   let uploadFileInFlight = false;
@@ -214,6 +217,14 @@ export function createSearchHandlers(deps: SearchHandlersDeps) {
       if (!response || !response.id) {
         throw new Error("Upload failed");
       }
+      onNormalTrackSelected?.({
+        id: response.id,
+        sourceType: "upload",
+        title: file.name || "Untitled",
+        artist: "",
+        duration: null,
+        tuningParams: state.playMode === "jukebox" ? state.tuningParams : null,
+      });
       resetForNewTrack(context);
       state.lastJobId = response.id;
       state.pendingAutoFavoriteId = response.id;
@@ -311,6 +322,27 @@ export function createSearchHandlers(deps: SearchHandlersDeps) {
         sourceProvider === "youtube"
           ? (sourceId as string)
           : response.id;
+      const playlistSourceType =
+        sourceProvider === "soundcloud" || sourceProvider === "bandcamp"
+          ? sourceProvider
+          : sourceProvider === "youtube"
+            ? "youtube"
+            : "upload";
+      const playlistId =
+        sourceId &&
+        (playlistSourceType === "soundcloud" ||
+          playlistSourceType === "bandcamp" ||
+          playlistSourceType === "youtube")
+          ? sourceId
+          : listenId;
+      onNormalTrackSelected?.({
+        id: playlistId,
+        sourceType: playlistSourceType,
+        title: "Untitled",
+        artist: "",
+        duration: null,
+        tuningParams: state.playMode === "jukebox" ? state.tuningParams : null,
+      });
       resetForNewTrack(context);
       state.lastTrackId = listenId;
       state.lastJobId = response.id;

--- a/web/src/app/wire/search.ts
+++ b/web/src/app/wire/search.ts
@@ -321,7 +321,10 @@ export function createSearchHandlers(deps: SearchHandlersDeps) {
       const listenId =
         sourceProvider === "youtube"
           ? (sourceId as string)
-          : response.id;
+          : sourceId &&
+              (sourceProvider === "soundcloud" || sourceProvider === "bandcamp")
+            ? `${sourceProvider}:${sourceId}`
+            : response.id;
       const playlistSourceType =
         sourceProvider === "soundcloud" || sourceProvider === "bandcamp"
           ? sourceProvider

--- a/web/src/app/wire/top-songs.ts
+++ b/web/src/app/wire/top-songs.ts
@@ -1,6 +1,8 @@
 import type { Elements } from "../elements";
 import type { TabId } from "../context";
 import { formatErrorForDisplay } from "../errorDisplay";
+import type { PlaylistTrack } from "../playlist";
+import { blurMouseActivatedControl } from "../ui";
 type TopSongsDeps = {
   elements: Elements;
   fetchTopSongs: (limit: number) => Promise<
@@ -12,13 +14,20 @@ type TopSongsDeps = {
   fetchRecentSongs: (limit: number) => Promise<
     Array<{ id?: string; title?: string; artist?: string; source_id?: string; source_provider?: string }>
   >;
-  loadTrackById: (trackId: string) => void;
-  loadTrackByJobId: (jobId: string) => void;
+  loadTrackById: (
+    trackId: string,
+    options?: { selectedTrack?: PlaylistTrack | null },
+  ) => void;
+  loadTrackByJobId: (
+    jobId: string,
+    options?: { selectedTrack?: PlaylistTrack | null },
+  ) => void;
   navigateToTabWithState: (
     tabId: TabId,
     options?: { replace?: boolean; trackId?: string | null },
   ) => void;
   limit: number;
+  onAddToPlaylist?: (track: PlaylistTrack) => void;
 };
 
 export type TopSongsHandlers = ReturnType<typeof createTopSongsHandlers>;
@@ -33,6 +42,7 @@ export function createTopSongsHandlers(deps: TopSongsDeps) {
     loadTrackByJobId,
     navigateToTabWithState,
     limit,
+    onAddToPlaylist,
   } = deps;
 
   function isLikelyJobId(value: string) {
@@ -65,18 +75,39 @@ export function createTopSongsHandlers(deps: TopSongsDeps) {
         const jobId = typeof item.id === "string" ? item.id : "";
         const sourceProvider =
           typeof item.source_provider === "string" ? item.source_provider : "";
+        const sourceType = normalizePlaylistSourceType(sourceProvider);
         const listenId =
           sourceProvider === "youtube" && sourceId
             ? sourceId
             : jobId;
         const li = document.createElement("li");
         if (listenId) {
+          li.className = "top-list-item";
           const link = document.createElement("a");
           link.href = `/listen/${encodeURIComponent(listenId)}`;
           link.textContent = artist ? `${title} — ${artist}` : title;
           link.dataset.trackId = listenId;
+          link.dataset.playlistId = getPlaylistTrackId(
+            sourceType,
+            sourceId,
+            jobId,
+            listenId,
+          );
+          link.dataset.sourceType = sourceType;
+          link.dataset.trackTitle = title;
+          link.dataset.trackArtist = artist;
           link.addEventListener("click", handleTopSongClick);
+          const addButton = createPlaylistAddButton({
+            id: link.dataset.playlistId,
+            sourceType,
+            title,
+            artist,
+            duration: null,
+          });
           li.appendChild(link);
+          if (addButton) {
+            li.appendChild(addButton);
+          }
         } else {
           li.textContent = artist ? `${title} — ${artist}` : title;
         }
@@ -126,12 +157,70 @@ export function createTopSongsHandlers(deps: TopSongsDeps) {
     if (!trackId) {
       return;
     }
+    const selectedTrack = getPlaylistTrackFromDataset(target);
     navigateToTabWithState("play", { trackId });
     if (isLikelyJobId(trackId)) {
-      loadTrackByJobId(trackId);
+      loadTrackByJobId(trackId, { selectedTrack });
       return;
     }
-    loadTrackById(trackId);
+    loadTrackById(trackId, { selectedTrack });
+  }
+
+  function getPlaylistTrackFromDataset(target: HTMLElement): PlaylistTrack | null {
+    const id = target.dataset.playlistId;
+    const sourceType = normalizePlaylistSourceType(target.dataset.sourceType ?? "");
+    if (!id) {
+      return null;
+    }
+    return {
+      id,
+      sourceType,
+      title: target.dataset.trackTitle || "Untitled",
+      artist: target.dataset.trackArtist || "",
+      duration: null,
+    };
+  }
+
+  function createPlaylistAddButton(track: PlaylistTrack) {
+    if (!onAddToPlaylist || !track.id) {
+      return null;
+    }
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "playlist-add-button";
+    button.title = "Add to playlist";
+    button.setAttribute("aria-label", `Add ${track.title || "track"} to playlist`);
+    button.innerHTML =
+      '<span class="material-symbols-outlined playlist-add-icon" aria-hidden="true">add_circle</span>';
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onAddToPlaylist(track);
+      blurMouseActivatedControl(event);
+    });
+    return button;
+  }
+
+  function normalizePlaylistSourceType(value: string): PlaylistTrack["sourceType"] {
+    if (value === "soundcloud" || value === "bandcamp" || value === "upload") {
+      return value;
+    }
+    return "youtube";
+  }
+
+  function getPlaylistTrackId(
+    sourceType: PlaylistTrack["sourceType"],
+    sourceId: string,
+    jobId: string,
+    listenId: string,
+  ) {
+    if (sourceType === "youtube") {
+      return sourceId || listenId;
+    }
+    if (sourceType === "soundcloud" || sourceType === "bandcamp") {
+      return sourceId || jobId || listenId;
+    }
+    return jobId || listenId;
   }
 
   return { fetchTopSongsList, fetchTrendingSongsList, fetchRecentSongsList };

--- a/web/src/app/wire/ui.ts
+++ b/web/src/app/wire/ui.ts
@@ -268,6 +268,7 @@ export function bindUiHandlers(deps: UiBindingsDeps) {
   );
   document.addEventListener("click", tuningHandlers.handleVolumeDocumentClick);
   window.addEventListener("keydown", deleteJobHandlers.handleDeleteConfirmKeydown);
+  window.addEventListener("keydown", playlistHandlers.handlePlaylistModalKeydown);
   window.addEventListener("keydown", playbackHandlers.handleKeydown);
   window.addEventListener("keyup", playbackHandlers.handleKeyup);
 

--- a/web/src/app/wire/ui.ts
+++ b/web/src/app/wire/ui.ts
@@ -9,6 +9,7 @@ import type { FullscreenHandlers } from "./fullscreen";
 import type { DeleteJobHandlers } from "./delete-job";
 import type { ThemeHandlers } from "./theme";
 import type { CacheHandlers } from "./cache";
+import type { PlaylistHandlers } from "./playlist";
 
 type UiBindingsDeps = {
   elements: Elements;
@@ -22,6 +23,7 @@ type UiBindingsDeps = {
   deleteJobHandlers: DeleteJobHandlers;
   themeHandlers: ThemeHandlers;
   cacheHandlers: CacheHandlers;
+  playlistHandlers: PlaylistHandlers;
 };
 
 export function bindUiHandlers(deps: UiBindingsDeps) {
@@ -37,6 +39,7 @@ export function bindUiHandlers(deps: UiBindingsDeps) {
     deleteJobHandlers,
     themeHandlers,
     cacheHandlers,
+    playlistHandlers,
   } = deps;
 
   elements.tabButtons.forEach((button) => {
@@ -146,6 +149,34 @@ export function bindUiHandlers(deps: UiBindingsDeps) {
   elements.favoriteButton.addEventListener(
     "click",
     favoritesHandlers.handleFavoriteToggle,
+  );
+  elements.playlistButton.addEventListener(
+    "click",
+    playlistHandlers.handleOpenPlaylist,
+  );
+  elements.playlistPreviousButton.addEventListener(
+    "click",
+    playlistHandlers.handlePlaylistPrevious,
+  );
+  elements.playlistNextButton.addEventListener(
+    "click",
+    playlistHandlers.handlePlaylistNext,
+  );
+  elements.savedPlaylistButton.addEventListener(
+    "click",
+    playlistHandlers.handleSavedPlaylistClick,
+  );
+  elements.playlistClose.addEventListener(
+    "click",
+    playlistHandlers.handleClosePlaylist,
+  );
+  elements.playlistModal.addEventListener(
+    "click",
+    playlistHandlers.handlePlaylistModalClick,
+  );
+  elements.playlistClearButton.addEventListener(
+    "click",
+    playlistHandlers.handleClearPlaylist,
   );
   elements.deleteButton.addEventListener(
     "click",

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -158,7 +158,7 @@ button,
   }
   3% {
     opacity: 0.75;
-    border-color: color-mix(in srgb, var(--title-accent) 78%, black);
+    border-color: color-mix(in srgb, var(--title-accent) 78%, var(--bg));
     box-shadow:
       0 0 5px color-mix(in srgb, var(--title-glow) 78%, transparent),
       inset 0 0 3px color-mix(in srgb, var(--title-glow) 35%, transparent);
@@ -187,7 +187,7 @@ button,
   }
   44% {
     opacity: 0.7;
-    border-color: color-mix(in srgb, var(--title-accent) 74%, black);
+    border-color: color-mix(in srgb, var(--title-accent) 74%, var(--bg));
     box-shadow:
       0 0 4px color-mix(in srgb, var(--title-glow) 72%, transparent),
       inset 0 0 3px color-mix(in srgb, var(--title-glow) 30%, transparent);
@@ -384,7 +384,7 @@ a:focus-visible {
   border-radius: 8px;
   border: 1px solid var(--border-control);
   background: var(--surface-panel);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 12px 24px var(--shadow-soft);
   z-index: 10;
 }
 
@@ -676,7 +676,7 @@ button.is-loading::after {
   display: none;
   align-items: center;
   justify-content: center;
-  background: rgba(10, 12, 16, 0.75);
+  background: var(--scrim);
   z-index: 20;
 }
 
@@ -823,7 +823,7 @@ button.is-loading::after {
 }
 
 .modal-status.error {
-  color: #e35a5a;
+  color: var(--danger);
 }
 
 .info-body {
@@ -860,12 +860,12 @@ button.is-loading::after {
 }
 
 .danger-button {
-  border-color: #e35a5a;
-  color: #e35a5a;
+  border-color: var(--danger);
+  color: var(--danger);
 }
 
 .danger-button:hover {
-  background: color-mix(in srgb, #e35a5a 14%, var(--surface-panel));
+  background: color-mix(in srgb, var(--danger) 14%, var(--surface-panel));
 }
 
 .sleep-timer-panel {
@@ -1006,6 +1006,19 @@ button.is-loading::after {
   padding: 2px 8px;
 }
 
+.top-list-item {
+  position: relative;
+  min-height: 20px;
+  padding-right: 28px;
+}
+
+.top-list-item .playlist-add-button {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+}
+
 .top-list > li:hover,
 .top-list > li:focus-within,
 .search-item:hover,
@@ -1100,7 +1113,7 @@ button.is-loading::after {
 .favorites-table .favorite-remove-heading,
 .favorites-table .favorite-remove-cell {
   text-align: right;
-  width: 42px;
+  width: 72px;
 }
 
 .favorite-row a {
@@ -1124,19 +1137,80 @@ button.is-loading::after {
   width: 22px;
   height: 22px;
   padding: 0;
+  border: none;
   border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.14s ease;
+  transition:
+    background-color 0.14s ease,
+    color 0.14s ease,
+    opacity 0.14s ease;
 }
 
 .favorite-row:hover .favorite-remove,
 .favorite-row:focus-within .favorite-remove {
   opacity: 1;
   pointer-events: auto;
+}
+
+.playlist-add-button {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    background-color 0.14s ease,
+    color 0.14s ease,
+    opacity 0.14s ease;
+}
+
+body.playlist-add-enabled .playlist-add-button {
+  display: inline-flex;
+}
+
+body.playlist-add-enabled .top-list > li:hover .playlist-add-button,
+body.playlist-add-enabled .top-list > li:focus-within .playlist-add-button,
+body.playlist-add-enabled .search-item:hover .playlist-add-button,
+body.playlist-add-enabled .search-item:focus-within .playlist-add-button,
+body.playlist-add-enabled .favorite-row:hover .playlist-add-button,
+body.playlist-add-enabled .favorite-row:focus-within .playlist-add-button {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.playlist-add-button:hover {
+  background: var(--surface-control);
+  color: var(--text);
+}
+
+.favorite-remove:hover,
+.playlist-remove:hover {
+  background: var(--surface-control);
+  color: var(--text);
+}
+
+.playlist-add-icon {
+  font-variation-settings:
+    "FILL" 0,
+    "wght" 350,
+    "GRAD" 0,
+    "opsz" 20;
+  font-size: 20px;
+  line-height: 1;
 }
 
 .favorite-toggle {
@@ -1181,6 +1255,40 @@ button.is-loading::after {
   justify-content: center;
 }
 
+.playlist-control {
+  background: transparent;
+  border: none;
+  padding: 0 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.playlist-control:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.playlist-control-icon {
+  font-variation-settings:
+    "FILL" 0,
+    "wght" 300,
+    "GRAD" 0,
+    "opsz" 30;
+  color: var(--text);
+  font-size: 30px;
+  line-height: 1;
+}
+
+#playlist-previous .playlist-control-icon,
+#playlist-next .playlist-control-icon {
+  font-variation-settings:
+    "FILL" 1,
+    "wght" 300,
+    "GRAD" 0,
+    "opsz" 30;
+}
+
 .delete-toggle {
   background: transparent;
   border: none;
@@ -1201,7 +1309,7 @@ button.is-loading::after {
     "wght" 300,
     "GRAD" 0,
     "opsz" 30;
-  color: #e35a5a;
+  color: var(--danger);
   font-size: 30px;
   line-height: 1;
 }
@@ -1264,6 +1372,7 @@ button.is-loading::after {
 .info-toggle,
 .copy-toggle,
 .favorite-toggle,
+.playlist-control,
 .favorites-sync-button,
 .delete-toggle,
 .volume-button,
@@ -1366,7 +1475,6 @@ button.is-loading::after {
 
 .favorite-remove {
   background: transparent;
-  border: none;
 }
 
 .favorite-remove .favorite-remove-icon {
@@ -1375,7 +1483,7 @@ button.is-loading::after {
     "wght" 300,
     "GRAD" 0,
     "opsz" 20;
-  color: var(--text);
+  color: currentColor;
   font-size: 20px;
   line-height: 1;
 }
@@ -1483,14 +1591,14 @@ button.is-loading::after {
   background: var(--surface-panel);
   color: var(--text);
   font-size: 13px;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 8px 20px var(--shadow-elevated);
   z-index: 30;
 }
 
 .toast.error {
-  border-color: #7f1d1d;
-  background: #3b1212;
-  color: #fecaca;
+  border-color: var(--danger-border);
+  background: var(--danger-surface);
+  color: var(--danger-text);
 }
 
 .toast.has-icon {
@@ -1515,7 +1623,7 @@ button.is-loading::after {
 }
 
 .toast.error .toast-icon {
-  color: #fecaca;
+  color: var(--danger-text);
 }
 
 .search-input {
@@ -1593,6 +1701,129 @@ button.is-loading::after {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+}
+
+.saved-playlist-button {
+  border-radius: 8px;
+  padding: 8px 10px;
+  white-space: nowrap;
+}
+
+.playlist-panel {
+  max-width: 560px;
+  max-height: calc(100dvh - 32px);
+}
+
+.playlist-list-wrap {
+  min-height: 64px;
+  max-height: min(360px, calc(100dvh - 180px));
+  overflow-y: auto;
+  padding-right: 4px;
+  color: var(--muted);
+}
+
+.playlist-panel .modal-body {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.playlist-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.playlist-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 32px;
+  gap: 8px;
+  align-items: center;
+  border-radius: 8px;
+  transition: background-color 0.16s ease;
+}
+
+.playlist-item.is-current {
+  background: color-mix(in srgb, var(--surface-control-hover) 72%, transparent);
+}
+
+.playlist-item:hover,
+.playlist-item:focus-within {
+  background: color-mix(in srgb, var(--surface-control-hover) 82%, transparent);
+}
+
+.playlist-select {
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  padding: 8px;
+  border-radius: 8px;
+  text-align: left;
+  display: grid;
+  gap: 2px;
+  cursor: pointer;
+}
+
+.playlist-select:disabled {
+  opacity: 1;
+  cursor: default;
+}
+
+.playlist-select:hover,
+.playlist-select:focus-visible {
+  background: transparent;
+}
+
+.playlist-item-title,
+.playlist-item-artist {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.playlist-item-title {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.playlist-item-artist {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.playlist-remove {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background-color 0.14s ease,
+    color 0.14s ease;
+}
+
+.playlist-remove:disabled {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.playlist-remove-icon {
+  font-variation-settings:
+    "FILL" 0,
+    "wght" 300,
+    "GRAD" 0,
+    "opsz" 20;
+  color: currentColor;
+  font-size: 20px;
+  line-height: 1;
 }
 
 .search-open {
@@ -1738,7 +1969,7 @@ button.is-loading::after {
   background: transparent;
   border: none;
   border-radius: 8px;
-  color: #e35a5a;
+  color: var(--danger);
   padding: 0 6px;
   min-width: 32px;
   min-height: 32px;
@@ -1760,7 +1991,7 @@ button.is-loading::after {
     "wght" 300,
     "GRAD" 0,
     "opsz" 20;
-  color: #e35a5a;
+  color: var(--danger);
   font-size: 25px;
   line-height: 1;
 }
@@ -1837,6 +2068,23 @@ button.is-loading::after {
   flex: 1;
 }
 
+.viz-bottom-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.volume-control-wrap {
+  position: relative;
+}
+
+.viz-play-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+
 .viz-play-toggle {
   display: inline-flex;
   padding: 0;
@@ -1845,6 +2093,11 @@ button.is-loading::after {
   border-radius: 8px;
   justify-content: center;
   flex: 0 0 auto;
+}
+
+#viz-panel:fullscreen .playlist-open-control,
+#viz-panel:-webkit-full-screen .playlist-open-control {
+  display: none;
 }
 
 .viz-info {
@@ -1889,6 +2142,14 @@ button.is-loading::after {
   gap: 6px;
   font-size: 12px;
   color: var(--muted);
+}
+
+.viz-meta-stats {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 6px;
+  white-space: nowrap;
 }
 
 .viz-divider {
@@ -2035,8 +2296,8 @@ button.is-loading::after {
 
 @media (max-width: 600px) {
   #app {
-    margin: 8px auto;
-    padding: 0 8px;
+    margin: 0;
+    padding: 0;
   }
 
   .tab-label-top-full,
@@ -2080,5 +2341,37 @@ button.is-loading::after {
     min-height: 18px;
     text-align: center;
     padding: 1px 4px;
+  }
+
+  .panel {
+    padding: 0;
+  }
+
+  .play-title {
+    padding-left: 6px;
+  }
+
+  #viz-stats {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  #viz-stats .viz-bottom-left {
+    display: contents;
+  }
+
+  #viz-stats .viz-play-controls,
+  #viz-stats .viz-play-toggle {
+    order: 1;
+  }
+
+  #viz-stats .viz-bottom-right {
+    order: 2;
+    margin-left: auto;
+  }
+
+  #viz-stats .viz-info {
+    order: 3;
+    flex: 0 0 100%;
   }
 }


### PR DESCRIPTION
Adds a web-only playlist feature backed by `localStorage`. Users can build a playlist after loading a track, add playable tracks from Top, Trending, Recently Played, and Favorites, then manage playback from the Listen screen.

**Highlights**
- Adds playlist state/model with max 10 tracks, duplicate detection, persistence, restore handling, removal rules, and current-index behavior.
- Adds playlist controls to the Listen UI: queue modal, previous/next controls, saved playlist restore entry, and modal select/remove/clear actions.
- Supports active playlist behavior when loading normal tracks: replacing the current playlist slot while keeping the playlist intact.
- Supports URL restore behavior with saved playlists: matches existing tracks, or inserts the URL-loaded track as the last playlist item.
- Integrates Autocanonizer auto-advance while preserving normal Jukebox endless playback behavior.
- Updates hover/focus behavior, responsive modal scrolling, icon placement, filled skip icons, and theme-color usage.
- Updates FAQ and June 2026 What's New copy for playlists.