### PR TITLE
crawlable tab links, per-page titles, HEAD support

### DIFF
--- a/api/api/main.py
+++ b/api/api/main.py
@@ -69,6 +69,26 @@ SITE_DESCRIPTION = (
     "seamlessly jumping between similar beats to remix it on the fly."
 )
 
+# Distinct per-page name/description for the indexable non-root routes. Without these,
+# every sitemap URL serves identical pre-render HTML and crawlers treat the pages as
+# duplicates of the homepage. Page names mirror the client's document-title format
+# (document-title.ts renders "<Page> | Forever Jukebox").
+PAGE_META = {
+    "search": (
+        "Search",
+        "Find any song and play it as a never-ending remix with The Forever Jukebox.",
+    ),
+    "faq": (
+        "FAQ",
+        "Answers to common questions about how The Forever Jukebox remixes songs "
+        "into infinite versions of themselves.",
+    ),
+    "whats-new": (
+        "What's New",
+        "The latest features and improvements to The Forever Jukebox.",
+    ),
+}
+
 
 def _attr(value: str) -> str:
     """Escape a string for use inside a double-quoted HTML attribute."""
@@ -178,6 +198,14 @@ def _inject_head(html: str, snippet: str) -> str:
     return snippet + html
 
 
+TITLE_TAG_RE = re.compile(r"<title>.*?</title>", re.DOTALL)
+
+
+def _set_title(html: str, title: str) -> str:
+    """Replace the document's <title> tag content."""
+    return TITLE_TAG_RE.sub(lambda _: f"<title>{escape(title)}</title>", html, count=1)
+
+
 @app.middleware("http")
 async def block_garbage_paths(request: Request, call_next):
     if WP_GARBAGE_RE.match(request.url.path):
@@ -200,7 +228,10 @@ def _shutdown() -> None:
     close_client()
 
 
-@app.get("/sitemap.xml", include_in_schema=False)
+# Public routes are registered for HEAD as well as GET: FastAPI's @app.get answers
+# HEAD with 405, but RFC 9110 §9.1 requires general-purpose servers to support both,
+# and link validators / crawlers probe with HEAD.
+@app.api_route("/sitemap.xml", methods=["GET", "HEAD"], include_in_schema=False)
 def sitemap_xml(request: Request):
     base_url = str(request.base_url).rstrip("/")
     entries = "".join(
@@ -220,7 +251,7 @@ def sitemap_xml(request: Request):
     return Response(content=content, media_type="application/xml")
 
 
-@app.get("/robots.txt", include_in_schema=False)
+@app.api_route("/robots.txt", methods=["GET", "HEAD"], include_in_schema=False)
 def robots_txt(request: Request):
     base_url = str(request.base_url).rstrip("/")
     content = (
@@ -246,14 +277,23 @@ if WEB_DIST.exists():
         page_url = base_url if not full_path else f"{base_url}/{full_path.lstrip('/')}"
         noindex = full_path == "listen" or full_path.startswith(LISTEN_PREFIX)
         extra = {}
+        doc_title = None
         if full_path.startswith(LISTEN_PREFIX):
             card = _listen_card(full_path[len(LISTEN_PREFIX) :])
             if card:
                 extra = {"title": card[0], "description": card[1], "og_type": "music.song"}
+                doc_title = f"{card[0]} | {SITE_NAME}"
+        elif full_path in PAGE_META:
+            page_name, description = PAGE_META[full_path]
+            doc_title = f"{page_name} | {SITE_NAME}"
+            extra = {"title": doc_title, "description": description}
         head = _head_meta(base_url, page_url, noindex=noindex, **extra)
-        return _inject_head(_index_template(), head)
+        html = _inject_head(_index_template(), head)
+        if doc_title:
+            html = _set_title(html, doc_title)
+        return html
 
-    @app.get("/{full_path:path}", responses=NOT_FOUND)
+    @app.api_route("/{full_path:path}", methods=["GET", "HEAD"], responses=NOT_FOUND)
     def spa_fallback(full_path: str, request: Request):
         if full_path.startswith("api"):
             raise HTTPException(status_code=404, detail="Not found")

--- a/api/tests/test_seo.py
+++ b/api/tests/test_seo.py
@@ -7,6 +7,7 @@ from starlette.requests import Request
 
 from api.main import (
     NOINDEX_META,
+    PAGE_META,
     SITE_AUTHOR,
     SITE_DESCRIPTION,
     SITE_NAME,
@@ -14,8 +15,10 @@ from api.main import (
     _head_meta,
     _inject_head,
     _parse_track_id,
+    _set_title,
     _social_meta,
     _track_card,
+    app,
     robots_txt,
     sitemap_xml,
 )
@@ -115,6 +118,47 @@ class HeadInjectionTests(unittest.TestCase):
         result = _inject_head("<div>no head here</div>", NOINDEX_META)
 
         self.assertIn(NOINDEX_META, result)
+
+
+class TitleTests(unittest.TestCase):
+    def test_replaces_template_title(self) -> None:
+        html = "<html><head><title>Forever Jukebox</title></head><body></body></html>"
+
+        result = _set_title(html, f"Search | {SITE_NAME}")
+
+        self.assertIn(f"<title>Search | {SITE_NAME}</title>", result)
+        self.assertNotIn("<title>Forever Jukebox</title>", result)
+
+    def test_escapes_title_text(self) -> None:
+        html = "<html><head><title>x</title></head></html>"
+
+        result = _set_title(html, "Song <b> & Artist")
+
+        self.assertIn("<title>Song &lt;b&gt; &amp; Artist</title>", result)
+
+
+class PageMetaTests(unittest.TestCase):
+    def test_every_page_meta_route_is_in_the_sitemap(self) -> None:
+        sitemap_paths = {path for path, _, _ in SITEMAP_PATHS}
+        for route in PAGE_META:
+            self.assertIn(f"/{route}", sitemap_paths)
+
+    def test_descriptions_are_distinct_from_the_default(self) -> None:
+        descriptions = {description for _, description in PAGE_META.values()}
+        descriptions.add(SITE_DESCRIPTION)
+        self.assertEqual(len(descriptions), len(PAGE_META) + 1)
+
+
+class HeadMethodTests(unittest.TestCase):
+    # RFC 9110 §9.1: general-purpose servers MUST support GET and HEAD; FastAPI's
+    # @app.get alone answers HEAD with 405.
+    def test_public_routes_accept_head(self) -> None:
+        methods_by_path = {
+            getattr(route, "path", None): getattr(route, "methods", set())
+            for route in app.routes
+        }
+        for path in ("/sitemap.xml", "/robots.txt"):
+            self.assertIn("HEAD", methods_by_path[path], path)
 
 
 class SocialMetaTests(unittest.TestCase):

--- a/web/src/app/components/TabBar.test.tsx
+++ b/web/src/app/components/TabBar.test.tsx
@@ -50,27 +50,35 @@ describe("TabBar", () => {
     expect(offline?.getAttribute("target")).toBe("_blank");
   });
 
+  it("renders tabs as crawlable links with real hrefs", () => {
+    renderTabBar();
+    expect(screen.getByText("Top Tracks").closest("a")?.getAttribute("href")).toBe("/");
+    expect(screen.getByText("Search").closest("a")?.getAttribute("href")).toBe("/search");
+    expect(screen.getByText("Listen").closest("a")?.getAttribute("href")).toBe("/listen");
+    expect(screen.getByText("FAQ").closest("a")?.getAttribute("href")).toBe("/faq");
+  });
+
   it("marks the active tab from the store", () => {
     renderTabBar();
-    const topButton = screen.getByText("Top Tracks").closest("button");
-    const searchButton = screen.getByText("Search").closest("button");
-    expect(topButton?.className).toContain("active");
-    expect(searchButton?.className).not.toContain("active");
+    const topTab = screen.getByText("Top Tracks").closest("a");
+    const searchTab = screen.getByText("Search").closest("a");
+    expect(topTab?.className).toContain("active");
+    expect(searchTab?.className).not.toContain("active");
     act(() => {
       useAppStore.getState().setActiveTab("search");
     });
-    expect(topButton?.className).not.toContain("active");
-    expect(searchButton?.className).toContain("active");
+    expect(topTab?.className).not.toContain("active");
+    expect(searchTab?.className).toContain("active");
   });
 
   it("pulses the Listen tab while audio runs on other tabs", () => {
     renderTabBar();
-    const playButton = screen.getByText("Listen").closest("button");
-    expect(playButton?.className).not.toContain("is-playing");
+    const playTab = screen.getByText("Listen").closest("a");
+    expect(playTab?.className).not.toContain("is-playing");
     act(() => {
       useAppStore.getState().setPlayTabPulsing(true);
     });
-    expect(playButton?.className).toContain("is-playing");
+    expect(playTab?.className).toContain("is-playing");
   });
 
   it("navigates via the store's selectTab action on click", async () => {

--- a/web/src/app/components/TabBar.tsx
+++ b/web/src/app/components/TabBar.tsx
@@ -1,6 +1,8 @@
+import type { MouseEvent } from "react";
 import type { TabId } from "../context";
 import { useAppStore } from "../store";
 import { useTranslation } from "react-i18next";
+import { pathForTab } from "../tabs";
 import { SettingsButton } from "./Hero";
 
 function tabClass(active: boolean, pulsing = false) {
@@ -15,38 +17,50 @@ export function TabBar() {
   const activeTab = useAppStore((s) => s.activeTabId);
   const isPlayTabPulsing = useAppStore((s) => s.isPlayTabPulsing);
   const selectTab = useAppStore((s) => s.selectTab);
-  const onClick = (tabId: TabId) => () => selectTab(tabId);
+  // Tabs are real links (crawlers only discover pages through anchor hrefs), but a
+  // plain left click must stay an in-app store navigation, not a page load.
+  const onClick = (tabId: TabId) => (event: MouseEvent<HTMLAnchorElement>) => {
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
+    event.preventDefault();
+    selectTab(tabId);
+  };
   return (
     <nav className="tabs" aria-label={t("navigation.primary")}>
-      <button
+      <a
         className={tabClass(activeTab === "top")}
         data-tab-button="top"
+        href={pathForTab("top")}
         onClick={onClick("top")}
       >
         <span className="tab-label-top-full">{t("navigation.topTracks")}</span>
         <span className="tab-label-top-short">{t("navigation.top")}</span>
-      </button>
-      <button
+      </a>
+      <a
         className={tabClass(activeTab === "search")}
         data-tab-button="search"
+        href={pathForTab("search")}
         onClick={onClick("search")}
       >
         {t("common.search")}
-      </button>
-      <button
+      </a>
+      <a
         className={tabClass(activeTab === "play", isPlayTabPulsing)}
         data-tab-button="play"
+        href={pathForTab("play")}
         onClick={onClick("play")}
       >
         {t("common.listen")}
-      </button>
-      <button
+      </a>
+      <a
         className={tabClass(activeTab === "faq")}
         data-tab-button="faq"
+        href={pathForTab("faq")}
         onClick={onClick("faq")}
       >
         {t("common.faq")}
-      </button>
+      </a>
       <a
         className="tab-btn tab-link"
         href="/offline/"

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -579,6 +579,11 @@ a:focus-visible {
 }
 
 .tab-btn {
+  /* Tabs are anchors (crawlable hrefs) styled to match buttons. */
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+  cursor: pointer;
   padding: 8px 14px;
   border-radius: 8px;
   border: 1px solid var(--border-control);


### PR DESCRIPTION
- Tab bar renders real anchors (crawlers only discover pages via hrefs); plain clicks still navigate through the store, modified clicks open the URL normally
- Server injects distinct <title> + meta description for /search, /faq, /whats-new, and track titles on /listen pages, so pre-render HTML is no longer identical across sitemap URLs
- Public GET routes also accept HEAD (RFC 9110 s9.1; FastAPI's @app.get alone answers HEAD with 405)