### PR TITLE
Threshold parity

### DIFF
--- a/packages/shared/src/engine/graph.test.ts
+++ b/packages/shared/src/engine/graph.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { normalizeAnalysis } from "./analysis";
-import { buildJumpGraph, calculateMinLongBranch } from "./graph";
+import {
+  buildJumpGraph,
+  calculateMinLongBranch,
+  parsePinnedThreshold,
+} from "./graph";
 import { Edge, JukeboxConfig, QuantumBase } from "./types";
 import {
   happyPathAnalysis,
@@ -1038,5 +1042,107 @@ describe("buildJumpGraph", () => {
     const graph = buildJumpGraph(analysis, config);
 
     expect(graph.lastBranchPoint).toBe(-1);
+  });
+});
+
+describe("parsePinnedThreshold", () => {
+  function label(raw: unknown) {
+    return typeof raw === "string" ? `"${raw}"` : String(raw);
+  }
+
+  const autoCases: unknown[] = [
+    undefined,
+    null,
+    "",
+    "0",
+    "1",
+    "-5",
+    "abc",
+    0,
+    1,
+    -5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    true,
+    {},
+  ];
+
+  for (const raw of autoCases) {
+    it(`reads ${label(raw)} as auto`, () => {
+      expect(parsePinnedThreshold(raw)).toBeNull();
+    });
+  }
+
+  const pinCases: Array<[unknown, number]> = [
+    ["2", 2],
+    ["45", 45],
+    ["45.7", 45],
+    ["80", 80],
+    ["81", 80],
+    ["500", 80],
+    [2, 2],
+    [45, 45],
+    [45.4, 45],
+    [45.6, 46],
+    [500, 80],
+  ];
+
+  for (const [raw, expected] of pinCases) {
+    it(`reads ${label(raw)} as a pin at ${expected}`, () => {
+      expect(parsePinnedThreshold(raw)).toBe(expected);
+    });
+  }
+});
+
+// A threshold of 0 asks the engine to pick one. These pin the shape of that
+// contract at the engine boundary: what goes in as a plain number, and what
+// comes back out as computedThreshold and the resolved currentThreshold.
+describe("threshold auto resolution", () => {
+  function denseAnalysis() {
+    return normalizeAnalysis(longBranchDensityAnalysis(96));
+  }
+
+  it("resolves a threshold of 0 to the computed default", () => {
+    const graph = buildJumpGraph(denseAnalysis(), defaultConfig({ currentThreshold: 0 }));
+
+    expect(graph.currentThreshold).toBe(graph.computedThreshold);
+    // Below the ceiling, so this exercises the sweep rather than its fallback.
+    expect(graph.computedThreshold).toBeLessThan(80);
+  });
+
+  it("computes a default inside the sweep range", () => {
+    const graph = buildJumpGraph(denseAnalysis(), defaultConfig({ currentThreshold: 0 }));
+
+    expect(graph.computedThreshold).toBeGreaterThanOrEqual(10);
+    expect(graph.computedThreshold).toBeLessThanOrEqual(80);
+    expect(graph.computedThreshold % 5).toBe(0);
+  });
+
+  it("uses a chosen threshold verbatim without moving the computed default", () => {
+    const auto = buildJumpGraph(denseAnalysis(), defaultConfig({ currentThreshold: 0 }));
+
+    for (const chosen of [2, 45, 80]) {
+      const graph = buildJumpGraph(
+        denseAnalysis(),
+        defaultConfig({ currentThreshold: chosen }),
+      );
+      expect(graph.currentThreshold).toBe(chosen);
+      expect(graph.computedThreshold).toBe(auto.computedThreshold);
+    }
+  });
+
+  it("leaves the caller's config untouched", () => {
+    const config = defaultConfig({ currentThreshold: 0 });
+    buildJumpGraph(denseAnalysis(), config);
+
+    expect(config.currentThreshold).toBe(0);
+  });
+
+  it("resolves the same pair for the same inputs", () => {
+    const first = buildJumpGraph(denseAnalysis(), defaultConfig({ currentThreshold: 0 }));
+    const second = buildJumpGraph(denseAnalysis(), defaultConfig({ currentThreshold: 0 }));
+
+    expect(second.computedThreshold).toBe(first.computedThreshold);
+    expect(second.currentThreshold).toBe(first.currentThreshold);
   });
 });

--- a/packages/shared/src/engine/graph.ts
+++ b/packages/shared/src/engine/graph.ts
@@ -16,6 +16,32 @@ const CONFIDENCE_WEIGHT = 1;
 
 export const DEFAULT_MIN_LONG_BRANCH_PERCENT = 20;
 
+// Floor and ceiling for a threshold a user or a stored param can pin. The floor
+// is unrelated to the sweep floor of 10 in computeDefaultThreshold: a computed
+// default can never land below 10, but 2..9 are meaningful pins. The ceiling
+// mirrors the default maxBranchThreshold, above which a threshold saturates
+// because edges are only precalculated that far; the two are kept equal by
+// convention rather than by construction.
+export const MIN_THRESHOLD = 2;
+export const MAX_THRESHOLD = 80;
+
+// Reads a pinned threshold from a URL param or a stored config value. Auto is
+// the ground state, so anything that is not a usable pin — missing, unparseable,
+// negative, or below the floor — reads as null rather than as an error. Values
+// above the ceiling clamp, so the number that is reported is the number that acts.
+export function parsePinnedThreshold(raw: unknown): number | null {
+  let parsed = Number.NaN;
+  if (typeof raw === "string") {
+    parsed = Number.parseInt(raw, 10);
+  } else if (typeof raw === "number") {
+    parsed = Math.round(raw);
+  }
+  if (!Number.isFinite(parsed) || parsed < MIN_THRESHOLD) {
+    return null;
+  }
+  return Math.min(parsed, MAX_THRESHOLD);
+}
+
 export function calculateMinLongBranch(
   totalBeats: number,
   percent = DEFAULT_MIN_LONG_BRANCH_PERCENT,

--- a/pwa/src/app/routes/Listen.tsx
+++ b/pwa/src/app/routes/Listen.tsx
@@ -40,10 +40,10 @@ import {
 import { getOrCreateSwingBuffer } from "@forever-jukebox/shared/audio/swingBufferCache";
 import { renderSwingBuffer } from "@forever-jukebox/shared/audio/swingRenderer";
 import {
+  DEFAULT_JUKEBOX_CONFIG,
   DEFAULT_MIN_LONG_BRANCH_PERCENT,
   Edge,
   findBackwardTwin,
-  JukeboxConfig,
   JukeboxEngine,
 } from "@forever-jukebox/shared";
 import {
@@ -91,19 +91,6 @@ const STEP_ORDER: AnalyzeStage[] = [
   "ready",
 ];
 
-const DEFAULT_CONFIG: JukeboxConfig = {
-  maxBranches: 4,
-  maxBranchThreshold: 80,
-  currentThreshold: 0,
-  justBackwards: false,
-  justLongBranches: false,
-  removeSequentialBranches: false,
-  minRandomBranchChance: 0.18,
-  maxRandomBranchChance: 0.5,
-  randomBranchChanceDelta: 0.02,
-  minLongBranch: 0,
-  minLongBranchPercent: DEFAULT_MIN_LONG_BRANCH_PERCENT,
-};
 
 const CANONIZER_FINISH_STORAGE_KEY = "fj-canonizer-finish";
 const VISUALIZATION_STORAGE_KEY = "fj-viz";
@@ -772,19 +759,19 @@ export function Listen({ isActive = true }: { isActive?: boolean }) {
   const [tuneForm, setTuneForm] = React.useState<TuneFormState>({
     threshold: 0,
     computedThreshold: 0,
-    minProb: Math.round(DEFAULT_CONFIG.minRandomBranchChance * 100),
-    maxProb: Math.round(DEFAULT_CONFIG.maxRandomBranchChance * 100),
+    minProb: Math.round(DEFAULT_JUKEBOX_CONFIG.minRandomBranchChance * 100),
+    maxProb: Math.round(DEFAULT_JUKEBOX_CONFIG.maxRandomBranchChance * 100),
     ramp:
       Math.round(
-        DEFAULT_CONFIG.randomBranchChanceDelta *
+        DEFAULT_JUKEBOX_CONFIG.randomBranchChanceDelta *
           RANDOM_BRANCH_DELTA_PERCENT_SCALE *
           10,
       ) / 10,
     volume: 100,
     highlightAnchorBranch,
-    justBackwards: DEFAULT_CONFIG.justBackwards,
+    justBackwards: DEFAULT_JUKEBOX_CONFIG.justBackwards,
     minLongBranchPercent: 0,
-    removeSequentialBranches: DEFAULT_CONFIG.removeSequentialBranches,
+    removeSequentialBranches: DEFAULT_JUKEBOX_CONFIG.removeSequentialBranches,
   });
   const [extrasForm, setExtrasForm] = React.useState<ExtrasFormState>({
     branchStatsEnabled: resolveStoredBranchStatsEnabled(),
@@ -2175,7 +2162,7 @@ export function Listen({ isActive = true }: { isActive?: boolean }) {
       return;
     }
     engine.clearDeletedEdges();
-    engine.updateConfig(DEFAULT_CONFIG);
+    engine.updateConfig(DEFAULT_JUKEBOX_CONFIG);
     rebuildGraphAndSyncViz();
     clearSelectedBranch();
     syncTuneFormFromEngine();

--- a/pwa/src/core/infrastructure/cache/__tests__/tuningStore.test.ts
+++ b/pwa/src/core/infrastructure/cache/__tests__/tuningStore.test.ts
@@ -104,6 +104,16 @@ describe("tuningStore", () => {
     expect(config?.maxRandomBranchChance).toBeCloseTo(0.5, 4);
   });
 
+  it("reorders branch probabilities when a fallback inverts the pair", () => {
+    const config = loadStoredConfig({
+      ...sample.config,
+      minRandomBranchChance: 0.6,
+      maxRandomBranchChance: "high",
+    });
+    expect(config?.minRandomBranchChance).toBeCloseTo(0.5, 4);
+    expect(config?.maxRandomBranchChance).toBeCloseTo(0.6, 4);
+  });
+
   it("falls back to the default minimum jump distance when unusable", () => {
     const config = loadStoredConfig({ ...sample.config, minLongBranchPercent: 0 });
     expect(config?.minLongBranchPercent).toBe(20);

--- a/pwa/src/core/infrastructure/cache/__tests__/tuningStore.test.ts
+++ b/pwa/src/core/infrastructure/cache/__tests__/tuningStore.test.ts
@@ -55,6 +55,60 @@ describe("tuningStore", () => {
     expect(loadTuning("fp-2")).toEqual(sample);
   });
 
+  it("preserves valid thresholds across the slider range", () => {
+    for (const currentThreshold of [0, 2, 45, 80]) {
+      const stored = { ...sample, config: { ...sample.config, currentThreshold } };
+      saveTuning("fp-range", stored);
+      expect(loadTuning("fp-range")?.config.currentThreshold).toBe(currentThreshold);
+    }
+  });
+
+  function loadStoredConfig(config: unknown) {
+    window.localStorage.setItem(
+      "fj-tuning:fp-raw",
+      JSON.stringify({ ...sample, config }),
+    );
+    return loadTuning("fp-raw")?.config;
+  }
+
+  const thresholdCases: Array<[unknown, number]> = [
+    [null, 0],
+    ["45", 45],
+    [-1, 0],
+    [0, 0],
+    [1, 0],
+    [500, 80],
+    [45.6, 46],
+    [undefined, 0],
+  ];
+
+  for (const [stored, expected] of thresholdCases) {
+    it(`normalizes a stored threshold of ${String(stored)} to ${expected}`, () => {
+      const config = loadStoredConfig({ ...sample.config, currentThreshold: stored });
+      expect(config?.currentThreshold).toBe(expected);
+    });
+  }
+
+  it("falls back to engine defaults for non-boolean flags", () => {
+    const config = loadStoredConfig({ ...sample.config, justBackwards: "yes" });
+    expect(config?.justBackwards).toBe(false);
+  });
+
+  it("clamps out-of-range branch probabilities", () => {
+    const config = loadStoredConfig({
+      ...sample.config,
+      minRandomBranchChance: -2,
+      maxRandomBranchChance: Number.NaN,
+    });
+    expect(config?.minRandomBranchChance).toBe(0);
+    expect(config?.maxRandomBranchChance).toBeCloseTo(0.5, 4);
+  });
+
+  it("falls back to the default minimum jump distance when unusable", () => {
+    const config = loadStoredConfig({ ...sample.config, minLongBranchPercent: 0 });
+    expect(config?.minLongBranchPercent).toBe(20);
+  });
+
   it("clearAllTuning removes only fj-tuning: keys", () => {
     saveTuning("fp-1", sample);
     saveTuning("fp-2", sample);

--- a/pwa/src/core/infrastructure/cache/tuningStore.ts
+++ b/pwa/src/core/infrastructure/cache/tuningStore.ts
@@ -57,6 +57,27 @@ function numberInRange(
 function normalizeConfig(raw: Record<string, unknown>): SavedTuningConfig {
   const defaults = DEFAULT_JUKEBOX_CONFIG;
   const minLongBranchPercent = raw.minLongBranchPercent;
+  // Each probability is normalized on its own, so one falling back to its
+  // default can invert the pair. Reorder them the same way applying the tuning
+  // form does, rather than handing the engine a minimum above its maximum.
+  let minRandomBranchChance = numberInRange(
+    raw.minRandomBranchChance,
+    0,
+    1,
+    defaults.minRandomBranchChance,
+  );
+  let maxRandomBranchChance = numberInRange(
+    raw.maxRandomBranchChance,
+    0,
+    1,
+    defaults.maxRandomBranchChance,
+  );
+  if (minRandomBranchChance > maxRandomBranchChance) {
+    [minRandomBranchChance, maxRandomBranchChance] = [
+      maxRandomBranchChance,
+      minRandomBranchChance,
+    ];
+  }
   return {
     currentThreshold: parsePinnedThreshold(raw.currentThreshold) ?? 0,
     justBackwards: boolOr(raw.justBackwards, defaults.justBackwards),
@@ -65,18 +86,8 @@ function normalizeConfig(raw: Record<string, unknown>): SavedTuningConfig {
       raw.removeSequentialBranches,
       defaults.removeSequentialBranches,
     ),
-    minRandomBranchChance: numberInRange(
-      raw.minRandomBranchChance,
-      0,
-      1,
-      defaults.minRandomBranchChance,
-    ),
-    maxRandomBranchChance: numberInRange(
-      raw.maxRandomBranchChance,
-      0,
-      1,
-      defaults.maxRandomBranchChance,
-    ),
+    minRandomBranchChance,
+    maxRandomBranchChance,
     randomBranchChanceDelta: numberInRange(
       raw.randomBranchChanceDelta,
       0,

--- a/pwa/src/core/infrastructure/cache/tuningStore.ts
+++ b/pwa/src/core/infrastructure/cache/tuningStore.ts
@@ -1,4 +1,9 @@
-import type { JukeboxConfig } from "@forever-jukebox/shared";
+import {
+  DEFAULT_JUKEBOX_CONFIG,
+  DEFAULT_MIN_LONG_BRANCH_PERCENT,
+  parsePinnedThreshold,
+  type JukeboxConfig,
+} from "@forever-jukebox/shared";
 
 // Per-song tuning is auto-saved in localStorage, keyed by the same fingerprint
 // used for the cached analysis. Removal is centralized in analysisCache.ts so
@@ -28,6 +33,63 @@ export type SavedTuning = {
 
 function keyFor(fingerprint: string) {
   return `${PREFIX}${fingerprint}`;
+}
+
+function boolOr(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function numberInRange(
+  value: unknown,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
+// Stored tuning is hand-editable and survives app upgrades, so every field is
+// re-read rather than trusted. Anything unusable falls back to the engine
+// default, which for the threshold means auto.
+function normalizeConfig(raw: Record<string, unknown>): SavedTuningConfig {
+  const defaults = DEFAULT_JUKEBOX_CONFIG;
+  const minLongBranchPercent = raw.minLongBranchPercent;
+  return {
+    currentThreshold: parsePinnedThreshold(raw.currentThreshold) ?? 0,
+    justBackwards: boolOr(raw.justBackwards, defaults.justBackwards),
+    justLongBranches: boolOr(raw.justLongBranches, defaults.justLongBranches),
+    removeSequentialBranches: boolOr(
+      raw.removeSequentialBranches,
+      defaults.removeSequentialBranches,
+    ),
+    minRandomBranchChance: numberInRange(
+      raw.minRandomBranchChance,
+      0,
+      1,
+      defaults.minRandomBranchChance,
+    ),
+    maxRandomBranchChance: numberInRange(
+      raw.maxRandomBranchChance,
+      0,
+      1,
+      defaults.maxRandomBranchChance,
+    ),
+    randomBranchChanceDelta: numberInRange(
+      raw.randomBranchChanceDelta,
+      0,
+      1,
+      defaults.randomBranchChanceDelta,
+    ),
+    minLongBranchPercent:
+      typeof minLongBranchPercent === "number" &&
+      Number.isFinite(minLongBranchPercent) &&
+      minLongBranchPercent > 0
+        ? Math.min(minLongBranchPercent, 100)
+        : DEFAULT_MIN_LONG_BRANCH_PERCENT,
+  };
 }
 
 export function loadTuning(fingerprint: string): SavedTuning | null {
@@ -62,7 +124,7 @@ export function loadTuning(fingerprint: string): SavedTuning | null {
         : null;
     return {
       v: 1,
-      config: parsed.config as SavedTuningConfig,
+      config: normalizeConfig(parsed.config as Record<string, unknown>),
       deletedEdgeIds,
       anchorEdgeId,
     };

--- a/web/e2e/tuning.spec.ts
+++ b/web/e2e/tuning.spec.ts
@@ -126,6 +126,20 @@ test.describe("tuning modal", () => {
       ),
     ).toBe("1");
   });
+
+  test("computed hint reports the track default, not the pinned threshold", async ({
+    page,
+    request,
+    baseURL,
+  }) => {
+    const track = await getFixtureTrack(request, baseURL!);
+    // 51 is not a multiple of 5, so it can never be a computed default.
+    await loadTrackByDeepLink(page, track.id, "?thresh=51");
+    await page.locator("#tuning").click();
+    await expect(page.locator("#tuning-modal")).toHaveClass(/\bopen\b/);
+    await expect(page.locator("#threshold")).toHaveValue("51");
+    await expect(page.locator("#computed-threshold")).not.toHaveText("51");
+  });
 });
 
 test.describe("extras", () => {

--- a/web/src/app/context.ts
+++ b/web/src/app/context.ts
@@ -36,7 +36,6 @@ export type AppState = {
   analysisLoaded: boolean;
   audioLoadInFlight: boolean;
   analysisPollInFlight: boolean;
-  autoComputedThreshold: number | null;
   lastJobId: string | null;
   lastTrackId: string | null;
   lastSourceId: string | null;

--- a/web/src/app/playback.test.ts
+++ b/web/src/app/playback.test.ts
@@ -176,7 +176,7 @@ function createContext(overrides?: Partial<AppContext>): TestAppContext {
     }),
     rebuildGraph: vi.fn(),
     loadAnalysis: vi.fn(),
-    getGraphState: vi.fn(() => ({ currentThreshold: 45, computedThreshold: 45, allEdges: [], totalBeats: 0 })),
+    getGraphState: vi.fn(() => ({ currentThreshold: 45, computedThreshold: 30, allEdges: [], totalBeats: 0 })),
     getVisualizationData: vi.fn(() => ({ beats: [], edges: [] })),
     pauseJukebox: vi.fn(),
     syncToPlaybackPosition: vi.fn(),
@@ -336,7 +336,9 @@ describe("playback tuning", () => {
     useAppStore.setState({ highlightAnchorBranch: true });
     const form = getTuningFormValues(context);
     expect(form.threshold).toBe(45);
-    expect(form.computedThreshold).toBe(45);
+    // The graph fake resolves to 45 while computing 30, so this fails if the
+    // hint ever goes back to reporting the threshold in use.
+    expect(form.computedThreshold).toBe(30);
     expect(form.minProbPct).toBe(18);
     expect(form.maxProbPct).toBe(50);
     expect(form.minLongBranchPercent).toBe(0);
@@ -418,7 +420,7 @@ describe("playback tuning", () => {
         })),
         updateConfig: vi.fn(),
         rebuildGraph: vi.fn(),
-        getGraphState: vi.fn(() => ({ currentThreshold: 45, computedThreshold: 45, allEdges: [], totalBeats: 0 })),
+        getGraphState: vi.fn(() => ({ currentThreshold: 45, computedThreshold: 30, allEdges: [], totalBeats: 0 })),
         getVisualizationData: vi.fn(() => ({ beats: [1], edges: [1] })),
       } as unknown as AppContext["engine"],
       jukebox: {
@@ -764,7 +766,7 @@ describe("playback tuning", () => {
     setWindowUrl("http://localhost/listen/abc?d=1,3");
     const graph = {
       currentThreshold: 45,
-      computedThreshold: 45,
+      computedThreshold: 30,
       allEdges: [
         { id: 1, deleted: false },
         { id: 2, deleted: false },
@@ -868,7 +870,7 @@ describe("playback tuning", () => {
         getSectionStartBeatIndices: vi.fn(() => []),
         getGraphState: vi.fn(() => ({
           currentThreshold: 45,
-          computedThreshold: 45,
+          computedThreshold: 30,
           allEdges: [anchorEdge],
           totalBeats: 0,
         })),
@@ -917,7 +919,7 @@ describe("playback tuning", () => {
         getSectionStartBeatIndices: vi.fn(() => []),
         getGraphState: vi.fn(() => ({
           currentThreshold: 45,
-          computedThreshold: 45,
+          computedThreshold: 30,
           allEdges: [forwardEdge],
           totalBeats: 0,
         })),
@@ -955,7 +957,7 @@ describe("playback tuning", () => {
         updateConfig: vi.fn(),
         loadAnalysis: vi.fn(),
         getSectionStartBeatIndices: vi.fn(() => []),
-        getGraphState: vi.fn(() => ({ currentThreshold: 45, computedThreshold: 45, allEdges: [], totalBeats: 0 })),
+        getGraphState: vi.fn(() => ({ currentThreshold: 45, computedThreshold: 30, allEdges: [], totalBeats: 0 })),
         getVisualizationData: vi.fn(() => ({ beats: [], edges: [] })),
         deleteEdge: vi.fn(),
         rebuildGraph: vi.fn(),
@@ -994,7 +996,7 @@ describe("playback tuning", () => {
         updateConfig: vi.fn(),
         loadAnalysis: vi.fn(),
         getSectionStartBeatIndices: vi.fn(() => [4, 12]),
-        getGraphState: vi.fn(() => ({ currentThreshold: 45, computedThreshold: 45, allEdges: [], totalBeats: 0 })),
+        getGraphState: vi.fn(() => ({ currentThreshold: 45, computedThreshold: 30, allEdges: [], totalBeats: 0 })),
         getVisualizationData: vi.fn(() => ({ beats: [], edges: [] })),
         deleteEdge: vi.fn(),
         rebuildGraph: vi.fn(),
@@ -1048,7 +1050,7 @@ describe("playback tuning", () => {
     setWindowUrl("http://localhost/listen/abc?thresh=20&d=2");
     const graph = {
       currentThreshold: 45,
-      computedThreshold: 45,
+      computedThreshold: 30,
       allEdges: [
         { id: 2, deleted: false },
         { id: 3, deleted: false },

--- a/web/src/app/playback.test.ts
+++ b/web/src/app/playback.test.ts
@@ -176,7 +176,7 @@ function createContext(overrides?: Partial<AppContext>): TestAppContext {
     }),
     rebuildGraph: vi.fn(),
     loadAnalysis: vi.fn(),
-    getGraphState: vi.fn(() => ({ currentThreshold: 45, allEdges: [], totalBeats: 0 })),
+    getGraphState: vi.fn(() => ({ currentThreshold: 45, computedThreshold: 45, allEdges: [], totalBeats: 0 })),
     getVisualizationData: vi.fn(() => ({ beats: [], edges: [] })),
     pauseJukebox: vi.fn(),
     syncToPlaybackPosition: vi.fn(),
@@ -418,7 +418,7 @@ describe("playback tuning", () => {
         })),
         updateConfig: vi.fn(),
         rebuildGraph: vi.fn(),
-        getGraphState: vi.fn(() => ({ currentThreshold: 45, allEdges: [], totalBeats: 0 })),
+        getGraphState: vi.fn(() => ({ currentThreshold: 45, computedThreshold: 45, allEdges: [], totalBeats: 0 })),
         getVisualizationData: vi.fn(() => ({ beats: [1], edges: [1] })),
       } as unknown as AppContext["engine"],
       jukebox: {
@@ -764,6 +764,7 @@ describe("playback tuning", () => {
     setWindowUrl("http://localhost/listen/abc?d=1,3");
     const graph = {
       currentThreshold: 45,
+      computedThreshold: 45,
       allEdges: [
         { id: 1, deleted: false },
         { id: 2, deleted: false },
@@ -867,6 +868,7 @@ describe("playback tuning", () => {
         getSectionStartBeatIndices: vi.fn(() => []),
         getGraphState: vi.fn(() => ({
           currentThreshold: 45,
+          computedThreshold: 45,
           allEdges: [anchorEdge],
           totalBeats: 0,
         })),
@@ -915,6 +917,7 @@ describe("playback tuning", () => {
         getSectionStartBeatIndices: vi.fn(() => []),
         getGraphState: vi.fn(() => ({
           currentThreshold: 45,
+          computedThreshold: 45,
           allEdges: [forwardEdge],
           totalBeats: 0,
         })),
@@ -952,7 +955,7 @@ describe("playback tuning", () => {
         updateConfig: vi.fn(),
         loadAnalysis: vi.fn(),
         getSectionStartBeatIndices: vi.fn(() => []),
-        getGraphState: vi.fn(() => ({ currentThreshold: 45, allEdges: [], totalBeats: 0 })),
+        getGraphState: vi.fn(() => ({ currentThreshold: 45, computedThreshold: 45, allEdges: [], totalBeats: 0 })),
         getVisualizationData: vi.fn(() => ({ beats: [], edges: [] })),
         deleteEdge: vi.fn(),
         rebuildGraph: vi.fn(),
@@ -991,7 +994,7 @@ describe("playback tuning", () => {
         updateConfig: vi.fn(),
         loadAnalysis: vi.fn(),
         getSectionStartBeatIndices: vi.fn(() => [4, 12]),
-        getGraphState: vi.fn(() => ({ currentThreshold: 45, allEdges: [], totalBeats: 0 })),
+        getGraphState: vi.fn(() => ({ currentThreshold: 45, computedThreshold: 45, allEdges: [], totalBeats: 0 })),
         getVisualizationData: vi.fn(() => ({ beats: [], edges: [] })),
         deleteEdge: vi.fn(),
         rebuildGraph: vi.fn(),
@@ -1045,6 +1048,7 @@ describe("playback tuning", () => {
     setWindowUrl("http://localhost/listen/abc?thresh=20&d=2");
     const graph = {
       currentThreshold: 45,
+      computedThreshold: 45,
       allEdges: [
         { id: 2, deleted: false },
         { id: 3, deleted: false },

--- a/web/src/app/playback/track-load.ts
+++ b/web/src/app/playback/track-load.ts
@@ -207,7 +207,6 @@ export function resetForNewTrack(
     stopPlayback(context);
   }
   autocanonizer?.reset();
-  useAppStore.setState({ autoComputedThreshold: null });
   if (shouldClearTuning) {
     useAppStore.setState({ tuningParams: null });
     clearTuningParamsFromUrl(true);
@@ -295,17 +294,11 @@ export function applyAnalysisResult(
     return false;
   }
   applyTuningParamsFromUrl(context);
-  const useAutoThreshold = engine.getConfig().currentThreshold === 0;
   engine.loadAnalysis(response.result);
   cowbellOverlay.setSectionStartBeatIndices(engine.getSectionStartBeatIndices());
   applyDeletedEdgesFromUrl(context);
   applyAnchorBranchFromUrl(context);
   autocanonizer.setAnalysis(response.result, response.result.track?.duration);
-  const graph = engine.getGraphState();
-  useAppStore.setState({
-    autoComputedThreshold:
-      useAutoThreshold && graph ? Math.round(graph.currentThreshold) : null,
-  });
   useAppStore.setState({ vizData: engine.getVisualizationData() });
   const data = useAppStore.getState().vizData;
   if (data) {

--- a/web/src/app/playback/tuning-forms.ts
+++ b/web/src/app/playback/tuning-forms.ts
@@ -275,9 +275,9 @@ export function getTuningFormValues(context: AppContext): TuningFormValues {
     config.currentThreshold === 0 && graph
       ? Math.round(graph.currentThreshold)
       : config.currentThreshold;
-  const computedValue =
-    useAppStore.getState().autoComputedThreshold ??
-    (graph ? Math.round(graph.currentThreshold) : null);
+  // The engine's own default for this track, which is not the threshold in use
+  // whenever the user has pinned one.
+  const computedValue = graph ? Math.round(graph.computedThreshold) : null;
   return {
     threshold: thresholdValue,
     computedThreshold: computedValue,
@@ -374,14 +374,12 @@ export function applyTuningChanges(
   let nextThreshold = threshold;
   let nextComputed: number | null;
   if (graph) {
-    const resolved = Math.max(0, Math.round(graph.currentThreshold));
     if (useAutoThreshold) {
-      useAppStore.setState({ autoComputedThreshold: resolved });
-      nextThreshold = resolved;
+      nextThreshold = Math.max(0, Math.round(graph.currentThreshold));
     }
-    nextComputed = resolved;
+    nextComputed = Math.round(graph.computedThreshold);
   } else {
-    nextComputed = useAppStore.getState().autoComputedThreshold;
+    nextComputed = form.computedThreshold;
   }
   for (const control of changedTuningControls(previousForm, form)) {
     trackEvent("tune", { control });
@@ -409,12 +407,6 @@ export function resetTuningDefaults(context: AppContext) {
     jukebox?.setData(data);
   }
   syncDeletedEdgeState(context);
-  const graph = engine.getGraphState();
-  useAppStore.setState({
-    autoComputedThreshold: graph
-    ? Math.round(graph.currentThreshold)
-    : null
-  });
   const { jukeboxAudioMode, audioIntensity } = useAppStore.getState();
   const audioModeParams = new URLSearchParams({ am: jukeboxAudioMode });
   setAudioModeIntensityParam(audioModeParams, jukeboxAudioMode, audioIntensity);

--- a/web/src/app/store.ts
+++ b/web/src/app/store.ts
@@ -452,14 +452,12 @@ const createTuningSlice: Slice<
   Pick<
     AppStoreState,
     | "tuningParams"
-    | "autoComputedThreshold"
     | "deletedEdgeIds"
     | "highlightAnchorBranch"
     | "branchStatsEnabled"
   >
 > = () => ({
   tuningParams: null,
-  autoComputedThreshold: null,
   deletedEdgeIds: [],
   highlightAnchorBranch: false,
   branchStatsEnabled: false,

--- a/web/src/app/tuning.test.ts
+++ b/web/src/app/tuning.test.ts
@@ -8,6 +8,7 @@ import {
   getAnchorBranchIdFromUrl,
   getDeletedEdgeIdsFromUrl,
   getTuningParamsFromEngine,
+  serializeParams,
   syncTuningParamsState,
   writeTuningParamsToUrl,
 } from "./tuning";
@@ -343,5 +344,65 @@ describe("tuning params", () => {
     expect(config.minRandomBranchChance).toBeCloseTo(0.25, 4);
     expect(config.maxRandomBranchChance).toBeCloseTo(0.5, 4);
     expect(config.randomBranchChanceDelta).toBeCloseTo(0.02, 4);
+  });
+});
+
+// The param string is the only tuning artefact that outlives the session: it is
+// stored verbatim on favorites and playlist entries and pasted into share links.
+// These assert what a given string reads back as, never how it is held.
+describe("threshold param round trip", () => {
+  beforeEach(() => {
+    setWindowUrl("http://localhost/listen/abc");
+  });
+
+  function readBack(raw: string) {
+    const context = createContext();
+    applyTuningParamsToEngine(context, new URLSearchParams(raw));
+    return serializeParams(getTuningParamsFromEngine(context));
+  }
+
+  function thresholdOf(raw: string) {
+    return new URLSearchParams(readBack(raw)).get("thresh");
+  }
+
+  const cases: Array<[string, string | null]> = [
+    ["thresh=45", "45"],
+    ["thresh=2", "2"],
+    ["thresh=80", "80"],
+    ["jb=1", null],
+    ["thresh=0", null],
+    ["thresh=-10", null],
+    ["thresh=abc", null],
+  ];
+
+  for (const [raw, expected] of cases) {
+    it(`reads "${raw}" as ${expected === null ? "no threshold" : expected}`, () => {
+      expect(thresholdOf(raw)).toBe(expected);
+    });
+  }
+
+  it("reads a threshold below the slider floor as auto", () => {
+    expect(thresholdOf("thresh=1")).toBeNull();
+  });
+
+  it("clamps a threshold above the ceiling to the value that acts", () => {
+    expect(thresholdOf("thresh=500")).toBe("80");
+  });
+
+  it("keeps a threshold distinct from the params beside it", () => {
+    expect(readBack("jb=1&thresh=45&bp=25,60,10")).toBe(
+      "jb=1&thresh=45&bp=25,60,10",
+    );
+  });
+
+  it("reads a threshold the same regardless of key order", () => {
+    expect(thresholdOf("bp=25,60,10&thresh=45&jb=1")).toBe("45");
+  });
+
+  it("settles after one read", () => {
+    for (const [raw] of cases) {
+      const once = readBack(raw);
+      expect(readBack(once)).toBe(once);
+    }
   });
 });

--- a/web/src/app/tuning.ts
+++ b/web/src/app/tuning.ts
@@ -1,6 +1,9 @@
 import type { AppContext } from "./context";
 import { useAppStore } from "./store";
-import { DEFAULT_MIN_LONG_BRANCH_PERCENT } from "@forever-jukebox/shared";
+import {
+  DEFAULT_MIN_LONG_BRANCH_PERCENT,
+  parsePinnedThreshold,
+} from "@forever-jukebox/shared";
 import {
   DEFAULT_AUDIO_MODE_INTENSITY,
   parseAudioModeIntensityParam,
@@ -140,10 +143,7 @@ export function applyTuningParamsToEngine(
     nextConfig.removeSequentialBranches = true;
   }
   if (params.has("thresh")) {
-    const raw = Number.parseInt(params.get("thresh") ?? "", 10);
-    if (Number.isFinite(raw) && raw >= 0) {
-      nextConfig.currentThreshold = raw;
-    }
+    nextConfig.currentThreshold = parsePinnedThreshold(params.get("thresh")) ?? 0;
   }
   if (params.has("bp")) {
     const fields = (params.get("bp") ?? "").split(",");


### PR DESCRIPTION
Route every pinned similarity threshold through one shared rule (`thresh` below 2 reads as auto, above 80 clamps), so `?thresh=1` no longer pins at 1 and a `thresh=500` no longer disagrees with the 80 it actually acts as. Also fixes the tuning modal's "computed threshold" hint, which showed the pinned value rather than the track's computed default, and validates pwa's persisted tuning blob field-by-field.