### PR TITLE
less ntfy notifications

### DIFF
--- a/api/api/db.py
+++ b/api/api/db.py
@@ -386,14 +386,24 @@ def get_notify_state(db_path: Path, key: str) -> Optional[str]:
     return str(row[0]) if row else None
 
 
-def set_notify_state(db_path: Path, key: str, value: str) -> None:
+def claim_notify_state(db_path: Path, key: str, expected: Optional[str], value: str) -> bool:
+    """Set the key to value only if it still holds expected; True when this caller won.
+
+    Lets concurrent workers agree on which one sends a notification.
+    """
     with _connect(db_path) as conn:
-        conn.execute(
-            "INSERT INTO notify_state (key, value) VALUES (?, ?) "
-            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-            (key, value),
-        )
+        if expected is None:
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO notify_state (key, value) VALUES (?, ?)",
+                (key, value),
+            )
+        else:
+            cur = conn.execute(
+                "UPDATE notify_state SET value = ? WHERE key = ? AND value = ?",
+                (value, key, expected),
+            )
         conn.commit()
+    return int(cur.rowcount or 0) > 0
 
 
 def recent_youtube_failure_errors(db_path: Path, since_iso: str) -> list[str]:

--- a/api/api/db.py
+++ b/api/api/db.py
@@ -380,6 +380,44 @@ def create_job(
         conn.commit()
 
 
+def get_notify_state(db_path: Path, key: str) -> Optional[str]:
+    with _connect(db_path) as conn:
+        row = conn.execute("SELECT value FROM notify_state WHERE key = ?", (key,)).fetchone()
+    return str(row[0]) if row else None
+
+
+def set_notify_state(db_path: Path, key: str, value: str) -> None:
+    with _connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO notify_state (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (key, value),
+        )
+        conn.commit()
+
+
+def recent_youtube_failure_errors(db_path: Path, since_iso: str) -> list[str]:
+    """Errors of YouTube jobs currently failed since the given timestamp.
+
+    Retried jobs reuse their row, so failures the user retried to success
+    no longer appear here.
+    """
+    with _connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT j.error
+            FROM jobs j
+            JOIN sources s ON s.id = j.source_ref
+            WHERE s.provider = 'youtube'
+              AND j.status = 'failed'
+              AND j.error IS NOT NULL
+              AND j.updated_at >= ?
+            """,
+            (since_iso,),
+        ).fetchall()
+    return [str(row[0]) for row in rows]
+
+
 def get_job(db_path: Path, job_id: str) -> Optional[Job]:
     with _connect(db_path) as conn:
         row = conn.execute(

--- a/api/api/db_migrations.py
+++ b/api/api/db_migrations.py
@@ -190,6 +190,14 @@ def _create_schema(conn: sqlite3.Connection) -> None:
         )
         """
     )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS notify_state (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+        """
+    )
     conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_status_created ON jobs(status, created_at, id)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_source_ref_created ON jobs(source_ref, created_at DESC)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_sources_provider ON sources(provider)")

--- a/api/api/routes/jobs_runtime.py
+++ b/api/api/routes/jobs_runtime.py
@@ -17,13 +17,13 @@ from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
 from ..db import (
+    claim_notify_state,
     delete_job,
     get_job,
     get_notify_state,
     recent_youtube_failure_errors,
     set_job_progress,
     set_job_status,
-    set_notify_state,
     update_job_track_metadata,
 )
 from ..env import env_positive_float
@@ -451,9 +451,11 @@ AGE_RESTRICTED_PATTERNS = (
 
 NOTIFY_FAILURE_THRESHOLD = 5
 NOTIFY_MIN_INTERVAL_S = 6 * 3600.0
-NOTIFY_FIRST_RUN_WINDOW_S = 24 * 3600.0
+NOTIFY_MAX_WINDOW_S = 24 * 3600.0
 NOTIFY_CHECK_INTERVAL_S = 60.0
 NOTIFY_LAST_SENT_KEY = "youtube_last_ntfy_at"
+# curl caps itself; subprocess gets a wider guard so curl exits on its own first.
+NTFY_TIMEOUT_S = 10.0
 
 _next_notify_check_monotonic = 0.0
 
@@ -471,12 +473,21 @@ def youtube_block_signal(raw: str | None) -> str | None:
 
 
 def _send_ntfy(topic_key: str, message: str) -> None:
+    """Post to ntfy, capped by a timeout so a stalled call cannot block a caller."""
     try:
         subprocess.run(
-            ["curl", "-d", message, f"ntfy.sh/{topic_key}"],
+            [
+                "curl",
+                "--max-time",
+                str(int(NTFY_TIMEOUT_S)),
+                "-d",
+                message,
+                f"ntfy.sh/{topic_key}",
+            ],
             check=False,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+            timeout=NTFY_TIMEOUT_S * 2,
         )
     except Exception:
         return
@@ -485,11 +496,12 @@ def _send_ntfy(topic_key: str, message: str) -> None:
 def maybe_notify_youtube_failures(db_path: Path = DB_PATH) -> None:
     """Ping ntfy when blocked-looking YouTube failures pile up.
 
-    Counts YouTube jobs still failed since the last ping (bounded to the
-    last 24h when no ping has been sent) and notifies once the count
-    reaches NOTIFY_FAILURE_THRESHOLD, at most once per NOTIFY_MIN_INTERVAL_S.
-    Safe to call every worker-loop iteration; the DB is only queried every
-    NOTIFY_CHECK_INTERVAL_S.
+    Counts YouTube jobs still failed since the last ping, over a window of at
+    most NOTIFY_MAX_WINDOW_S, and notifies once the count reaches
+    NOTIFY_FAILURE_THRESHOLD, at most once per NOTIFY_MIN_INTERVAL_S. Safe to
+    call every worker-loop iteration; the DB is only queried every
+    NOTIFY_CHECK_INTERVAL_S, and concurrent workers claim the send slot so
+    only one of them pings.
     """
     global _next_notify_check_monotonic
     topic_key = os.environ.get(NTFY_TOPIC_ENV)
@@ -500,12 +512,14 @@ def maybe_notify_youtube_failures(db_path: Path = DB_PATH) -> None:
         return
     _next_notify_check_monotonic = mono + NOTIFY_CHECK_INTERVAL_S
     now = datetime.now(timezone.utc)
-    last_sent = parse_timestamp(get_notify_state(db_path, NOTIFY_LAST_SENT_KEY))
+    stored_last_sent = get_notify_state(db_path, NOTIFY_LAST_SENT_KEY)
+    last_sent = parse_timestamp(stored_last_sent)
     if last_sent is not None and last_sent.tzinfo is None:
         last_sent = last_sent.replace(tzinfo=timezone.utc)
     if last_sent is not None and (now - last_sent).total_seconds() < NOTIFY_MIN_INTERVAL_S:
         return
-    since = last_sent or (now - timedelta(seconds=NOTIFY_FIRST_RUN_WINDOW_S))
+    window_start = now - timedelta(seconds=NOTIFY_MAX_WINDOW_S)
+    since = max(last_sent, window_start) if last_sent is not None else window_start
     labels = [
         label
         for label in (
@@ -516,6 +530,10 @@ def maybe_notify_youtube_failures(db_path: Path = DB_PATH) -> None:
     ]
     if len(labels) < NOTIFY_FAILURE_THRESHOLD:
         return
+    if not claim_notify_state(
+        db_path, NOTIFY_LAST_SENT_KEY, stored_last_sent, now.isoformat()
+    ):
+        return
     counts = Counter(labels)
     breakdown = ", ".join(f"{label} x{count}" for label, count in counts.most_common())
     hours = (now - since).total_seconds() / 3600.0
@@ -524,7 +542,6 @@ def maybe_notify_youtube_failures(db_path: Path = DB_PATH) -> None:
         f"in the last {hours:.1f}h ({breakdown})"
     )
     _send_ntfy(topic_key, message)
-    set_notify_state(db_path, NOTIFY_LAST_SENT_KEY, now.isoformat())
     log_event("ntfy_youtube_failures", count=len(labels), window_h=round(hours, 1))
 
 

--- a/api/api/routes/jobs_runtime.py
+++ b/api/api/routes/jobs_runtime.py
@@ -9,17 +9,21 @@ import re
 import shutil
 import subprocess
 import time
+from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
 from ..db import (
     delete_job,
     get_job,
+    get_notify_state,
+    recent_youtube_failure_errors,
     set_job_progress,
     set_job_status,
+    set_notify_state,
     update_job_track_metadata,
 )
 from ..env import env_positive_float
@@ -426,63 +430,102 @@ def message_for_progress(status: str, progress: int | None) -> str | None:
     return "Wrapping up"
 
 
-def _is_youtube_source_id(source_provider: str | None, source_id: str | None) -> bool:
-    if source_provider != "youtube":
-        return False
-    if not source_id:
-        return False
-    return bool(YOUTUBE_ID_RE.fullmatch(source_id))
+# Signals that a YouTube download failed because YouTube refused to serve
+# us (broken signatures, IP flagging, rate limiting) rather than because the
+# video itself is bad. Checked in order; first match wins.
+YOUTUBE_BLOCK_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("403", (HTTP_403_ERROR_TEXT, "unable to download video data")),
+    ("bot-check", ("sign in to confirm", "not a bot")),
+    ("429", ("http error 429", "too many requests")),
+    ("blocked", ("content isn't available",)),
+    ("network", ("timed out", "connection reset", "unable to connect")),
+)
+
+# Age restriction is a property of the video, not a block signal.
+AGE_RESTRICTED_PATTERNS = (
+    "sign in to confirm your age",
+    "inappropriate for some users",
+    "age-restricted",
+    "age restriction",
+)
+
+NOTIFY_FAILURE_THRESHOLD = 5
+NOTIFY_MIN_INTERVAL_S = 6 * 3600.0
+NOTIFY_FIRST_RUN_WINDOW_S = 24 * 3600.0
+NOTIFY_CHECK_INTERVAL_S = 60.0
+NOTIFY_LAST_SENT_KEY = "youtube_last_ntfy_at"
+
+_next_notify_check_monotonic = 0.0
 
 
-def _notify_youtube_issue(
-    raw: str | None,
-    source_provider: str | None,
-    source_id: str | None,
-    job_id: str,
-) -> None:
+def youtube_block_signal(raw: str | None) -> str | None:
     if not raw:
-        return
-    if not _is_youtube_source_id(source_provider, source_id):
-        return
-    topic_key = os.environ.get(NTFY_TOPIC_ENV)
-    if not topic_key:
-        return
+        return None
     lowered = raw.lower()
-    age_restricted = (
-        "sign in to confirm your age" in lowered
-        or "inappropriate for some users" in lowered
-        or "age-restricted" in lowered
-        or "age restriction" in lowered
-    )
-    if age_restricted:
-        return
-    issues: list[str] = []
-    if HTTP_403_ERROR_TEXT in lowered or "unable to download video data" in lowered:
-        issues.append("403: Forbidden")
-    if "sign in to confirm" in lowered or "not a bot" in lowered:
-        issues.append("Sign in to confirm you're not a bot")
-    if not issues:
-        return
-    video_label = source_id or "unknown"
-    log_path = f"/api/logs/{job_id}"
-    message = (
-        "[Forever Jukebox] Youtube error on "
-        + video_label
-        + ": "
-        + " or ".join(issues)
-        + " - "
-        + log_path
-    )
-    topic_url = f"ntfy.sh/{topic_key}"
+    if any(pattern in lowered for pattern in AGE_RESTRICTED_PATTERNS):
+        return None
+    for label, patterns in YOUTUBE_BLOCK_PATTERNS:
+        if any(pattern in lowered for pattern in patterns):
+            return label
+    return None
+
+
+def _send_ntfy(topic_key: str, message: str) -> None:
     try:
         subprocess.run(
-            ["curl", "-d", message, topic_url],
+            ["curl", "-d", message, f"ntfy.sh/{topic_key}"],
             check=False,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
     except Exception:
         return
+
+
+def maybe_notify_youtube_failures(db_path: Path = DB_PATH) -> None:
+    """Ping ntfy when blocked-looking YouTube failures pile up.
+
+    Counts YouTube jobs still failed since the last ping (bounded to the
+    last 24h when no ping has been sent) and notifies once the count
+    reaches NOTIFY_FAILURE_THRESHOLD, at most once per NOTIFY_MIN_INTERVAL_S.
+    Safe to call every worker-loop iteration; the DB is only queried every
+    NOTIFY_CHECK_INTERVAL_S.
+    """
+    global _next_notify_check_monotonic
+    topic_key = os.environ.get(NTFY_TOPIC_ENV)
+    if not topic_key:
+        return
+    mono = time.monotonic()
+    if mono < _next_notify_check_monotonic:
+        return
+    _next_notify_check_monotonic = mono + NOTIFY_CHECK_INTERVAL_S
+    now = datetime.now(timezone.utc)
+    last_sent = parse_timestamp(get_notify_state(db_path, NOTIFY_LAST_SENT_KEY))
+    if last_sent is not None and last_sent.tzinfo is None:
+        last_sent = last_sent.replace(tzinfo=timezone.utc)
+    if last_sent is not None and (now - last_sent).total_seconds() < NOTIFY_MIN_INTERVAL_S:
+        return
+    since = last_sent or (now - timedelta(seconds=NOTIFY_FIRST_RUN_WINDOW_S))
+    labels = [
+        label
+        for label in (
+            youtube_block_signal(error)
+            for error in recent_youtube_failure_errors(db_path, since.isoformat())
+        )
+        if label is not None
+    ]
+    if len(labels) < NOTIFY_FAILURE_THRESHOLD:
+        return
+    counts = Counter(labels)
+    breakdown = ", ".join(f"{label} x{count}" for label, count in counts.most_common())
+    hours = (now - since).total_seconds() / 3600.0
+    message = (
+        f"[Forever Jukebox] {len(labels)} YouTube download failures piled up "
+        f"in the last {hours:.1f}h ({breakdown})"
+    )
+    _send_ntfy(topic_key, message)
+    set_notify_state(db_path, NOTIFY_LAST_SENT_KEY, now.isoformat())
+    log_event("ntfy_youtube_failures", count=len(labels), window_h=round(hours, 1))
 
 
 def _write_failure_log(job_id: str, message: str) -> None:
@@ -495,10 +538,8 @@ def _write_failure_log(job_id: str, message: str) -> None:
 def cleanup_failure(
     job_id: str,
     message: str,
-    source_id: str | None = None,
     source_provider: str | None = None,
 ) -> None:
-    _notify_youtube_issue(message, source_provider, source_id, job_id)
     _write_failure_log(job_id, message)
     for candidate in (STORAGE_ROOT / "audio").glob(f"{job_id}.*"):
         if candidate.is_file():
@@ -577,7 +618,7 @@ def download_source_audio(
     try:
         from yt_dlp import YoutubeDL
     except Exception:
-        cleanup_failure(job_id, "yt-dlp is not available", source_id, source_provider)
+        cleanup_failure(job_id, "yt-dlp is not available", source_provider)
         return
 
     audio_dir = STORAGE_ROOT / "audio"
@@ -650,7 +691,7 @@ def download_source_audio(
             on_retry=discard_first_attempt,
         )
     except Exception as exc:  # pragma: no cover - network call
-        cleanup_failure(job_id, str(exc), source_id, source_provider)
+        cleanup_failure(job_id, str(exc), source_provider)
         return
 
     job = get_job(DB_PATH, job_id)
@@ -682,7 +723,7 @@ def download_source_audio(
                 break
 
     if not input_path:
-        cleanup_failure(job_id, "Download failed", source_id, source_provider)
+        cleanup_failure(job_id, "Download failed", source_provider)
         return
 
     # Normalize the downloaded file to audio/<id>.<ext> so it can be located

--- a/api/tests/test_youtube_notify.py
+++ b/api/tests/test_youtube_notify.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from api import db as db_module
+from api.db import (
+    create_job,
+    get_notify_state,
+    init_db,
+    set_job_status,
+    set_notify_state,
+)
+from api.routes import jobs_runtime as jobs_runtime_module
+from api.routes.jobs_runtime import (
+    NOTIFY_LAST_SENT_KEY,
+    maybe_notify_youtube_failures,
+    youtube_block_signal,
+)
+
+
+def _utc_iso(offset: timedelta = timedelta()) -> str:
+    return (datetime.now(timezone.utc) + offset).isoformat()
+
+
+class YoutubeBlockSignalTests(unittest.TestCase):
+    def test_labels_for_block_errors(self) -> None:
+        cases = {
+            "ERROR: unable to download video data: HTTP Error 403: Forbidden": "403",
+            "ERROR: Sign in to confirm you're not a bot": "bot-check",
+            "ERROR: HTTP Error 429: Too Many Requests": "429",
+            "ERROR: This content isn't available, try again later": "blocked",
+            "ERROR: Connection timed out": "network",
+            "ERROR: Connection reset by peer": "network",
+        }
+        for raw, expected in cases.items():
+            self.assertEqual(youtube_block_signal(raw), expected, raw)
+
+    def test_non_block_errors_return_none(self) -> None:
+        cases = [
+            None,
+            "",
+            "ERROR: Sign in to confirm your age",
+            "ERROR: This video is age-restricted",
+            "ERROR: Video unavailable",
+            "ERROR: Something went wrong.",
+        ]
+        for raw in cases:
+            self.assertIsNone(youtube_block_signal(raw), raw)
+
+
+class MaybeNotifyYoutubeFailuresTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        self.db_path = Path(temp_dir.name) / "jobs.db"
+        init_db(self.db_path)
+
+        env_patcher = patch.dict(
+            "os.environ", {jobs_runtime_module.NTFY_TOPIC_ENV: "test-topic"}
+        )
+        env_patcher.start()
+        self.addCleanup(env_patcher.stop)
+
+        send_patcher = patch.object(jobs_runtime_module, "_send_ntfy")
+        self.send_mock = send_patcher.start()
+        self.addCleanup(send_patcher.stop)
+
+        self._reset_throttle()
+
+    def _reset_throttle(self) -> None:
+        jobs_runtime_module._next_notify_check_monotonic = 0.0
+
+    def _seed_failures(
+        self,
+        count: int,
+        error: str = "ERROR: unable to download video data: HTTP Error 403: Forbidden",
+        provider: str = "youtube",
+        start: int = 0,
+    ) -> list[str]:
+        job_ids = []
+        for index in range(start, start + count):
+            job_id = f"job{index:04d}"
+            create_job(
+                self.db_path,
+                job_id,
+                source_id=f"vid{index:08d}",
+                source_provider=provider,
+            )
+            set_job_status(self.db_path, job_id, "failed", error)
+            job_ids.append(job_id)
+        return job_ids
+
+    def _set_updated_at(self, job_id: str, updated_at: str) -> None:
+        with db_module._connect(self.db_path) as conn:
+            conn.execute("UPDATE jobs SET updated_at = ? WHERE id = ?", (updated_at, job_id))
+            conn.commit()
+
+    def _sent_message(self) -> str:
+        self.assertEqual(self.send_mock.call_count, 1)
+        return self.send_mock.call_args[0][1]
+
+    def test_no_topic_env_short_circuits_before_db(self) -> None:
+        missing_db = Path("/nonexistent") / "jobs.db"
+        with patch.dict("os.environ", {}, clear=True):
+            maybe_notify_youtube_failures(missing_db)
+        self.send_mock.assert_not_called()
+
+    def test_below_threshold_stays_silent(self) -> None:
+        self._seed_failures(4)
+        maybe_notify_youtube_failures(self.db_path)
+        self.send_mock.assert_not_called()
+        self.assertIsNone(get_notify_state(self.db_path, NOTIFY_LAST_SENT_KEY))
+
+    def test_threshold_pings_with_count_and_breakdown(self) -> None:
+        self._seed_failures(3)
+        self._seed_failures(
+            2, error="ERROR: Sign in to confirm you're not a bot", start=3
+        )
+        maybe_notify_youtube_failures(self.db_path)
+        message = self._sent_message()
+        self.assertIn("5 YouTube download failures piled up", message)
+        self.assertIn("in the last 24.0h", message)
+        self.assertIn("403 x3", message)
+        self.assertIn("bot-check x2", message)
+        self.assertIsNotNone(get_notify_state(self.db_path, NOTIFY_LAST_SENT_KEY))
+
+    def test_non_youtube_failures_do_not_count(self) -> None:
+        self._seed_failures(5, provider="soundcloud")
+        maybe_notify_youtube_failures(self.db_path)
+        self.send_mock.assert_not_called()
+
+    def test_non_block_errors_do_not_count(self) -> None:
+        self._seed_failures(5, error="ERROR: Sign in to confirm your age")
+        maybe_notify_youtube_failures(self.db_path)
+        self.send_mock.assert_not_called()
+
+    def test_retried_to_success_leaves_the_count(self) -> None:
+        job_ids = self._seed_failures(5)
+        set_job_status(self.db_path, job_ids[0], "complete", None)
+        maybe_notify_youtube_failures(self.db_path)
+        self.send_mock.assert_not_called()
+
+    def test_failures_older_than_first_run_window_do_not_count(self) -> None:
+        job_ids = self._seed_failures(5)
+        self._set_updated_at(job_ids[0], _utc_iso(timedelta(hours=-25)))
+        maybe_notify_youtube_failures(self.db_path)
+        self.send_mock.assert_not_called()
+
+    def test_cooldown_suppresses_ping(self) -> None:
+        self._seed_failures(5)
+        set_notify_state(self.db_path, NOTIFY_LAST_SENT_KEY, _utc_iso(timedelta(hours=-1)))
+        maybe_notify_youtube_failures(self.db_path)
+        self.send_mock.assert_not_called()
+
+    def test_expired_cooldown_reports_pile_since_last_ping(self) -> None:
+        self._seed_failures(7)
+        set_notify_state(self.db_path, NOTIFY_LAST_SENT_KEY, _utc_iso(timedelta(hours=-7)))
+        maybe_notify_youtube_failures(self.db_path)
+        message = self._sent_message()
+        self.assertIn("7 YouTube download failures piled up", message)
+        self.assertIn("in the last 7.0h", message)
+
+    def test_failures_before_last_ping_do_not_count(self) -> None:
+        job_ids = self._seed_failures(7)
+        set_notify_state(self.db_path, NOTIFY_LAST_SENT_KEY, _utc_iso(timedelta(hours=-7)))
+        for job_id in job_ids[:3]:
+            self._set_updated_at(job_id, _utc_iso(timedelta(hours=-8)))
+        maybe_notify_youtube_failures(self.db_path)
+        self.send_mock.assert_not_called()
+
+    def test_check_throttle_skips_repeat_calls(self) -> None:
+        maybe_notify_youtube_failures(self.db_path)
+        self._seed_failures(5)
+        maybe_notify_youtube_failures(self.db_path)
+        self.send_mock.assert_not_called()
+        self._reset_throttle()
+        maybe_notify_youtube_failures(self.db_path)
+        self.assertEqual(self.send_mock.call_count, 1)
+
+    def test_notify_state_roundtrip_and_idempotent_init(self) -> None:
+        init_db(self.db_path)
+        set_notify_state(self.db_path, "k", "v1")
+        set_notify_state(self.db_path, "k", "v2")
+        self.assertEqual(get_notify_state(self.db_path, "k"), "v2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/tests/test_youtube_notify.py
+++ b/api/tests/test_youtube_notify.py
@@ -8,11 +8,11 @@ from unittest.mock import patch
 
 from api import db as db_module
 from api.db import (
+    claim_notify_state,
     create_job,
     get_notify_state,
     init_db,
     set_job_status,
-    set_notify_state,
 )
 from api.routes import jobs_runtime as jobs_runtime_module
 from api.routes.jobs_runtime import (
@@ -99,6 +99,11 @@ class MaybeNotifyYoutubeFailuresTests(unittest.TestCase):
             conn.execute("UPDATE jobs SET updated_at = ? WHERE id = ?", (updated_at, job_id))
             conn.commit()
 
+    def _set_last_sent(self, value: str) -> None:
+        self.assertTrue(
+            claim_notify_state(self.db_path, NOTIFY_LAST_SENT_KEY, None, value)
+        )
+
     def _sent_message(self) -> str:
         self.assertEqual(self.send_mock.call_count, 1)
         return self.send_mock.call_args[0][1]
@@ -152,13 +157,13 @@ class MaybeNotifyYoutubeFailuresTests(unittest.TestCase):
 
     def test_cooldown_suppresses_ping(self) -> None:
         self._seed_failures(5)
-        set_notify_state(self.db_path, NOTIFY_LAST_SENT_KEY, _utc_iso(timedelta(hours=-1)))
+        self._set_last_sent(_utc_iso(timedelta(hours=-1)))
         maybe_notify_youtube_failures(self.db_path)
         self.send_mock.assert_not_called()
 
     def test_expired_cooldown_reports_pile_since_last_ping(self) -> None:
         self._seed_failures(7)
-        set_notify_state(self.db_path, NOTIFY_LAST_SENT_KEY, _utc_iso(timedelta(hours=-7)))
+        self._set_last_sent(_utc_iso(timedelta(hours=-7)))
         maybe_notify_youtube_failures(self.db_path)
         message = self._sent_message()
         self.assertIn("7 YouTube download failures piled up", message)
@@ -166,7 +171,7 @@ class MaybeNotifyYoutubeFailuresTests(unittest.TestCase):
 
     def test_failures_before_last_ping_do_not_count(self) -> None:
         job_ids = self._seed_failures(7)
-        set_notify_state(self.db_path, NOTIFY_LAST_SENT_KEY, _utc_iso(timedelta(hours=-7)))
+        self._set_last_sent(_utc_iso(timedelta(hours=-7)))
         for job_id in job_ids[:3]:
             self._set_updated_at(job_id, _utc_iso(timedelta(hours=-8)))
         maybe_notify_youtube_failures(self.db_path)
@@ -181,10 +186,30 @@ class MaybeNotifyYoutubeFailuresTests(unittest.TestCase):
         maybe_notify_youtube_failures(self.db_path)
         self.assertEqual(self.send_mock.call_count, 1)
 
-    def test_notify_state_roundtrip_and_idempotent_init(self) -> None:
+    def test_window_is_capped_even_after_a_long_quiet_period(self) -> None:
+        job_ids = self._seed_failures(5)
+        self._set_last_sent(_utc_iso(timedelta(hours=-200)))
+        self._set_updated_at(job_ids[0], _utc_iso(timedelta(hours=-30)))
+        maybe_notify_youtube_failures(self.db_path)
+        self.send_mock.assert_not_called()
+
+        self._reset_throttle()
+        self._set_updated_at(job_ids[0], _utc_iso(timedelta(hours=-1)))
+        maybe_notify_youtube_failures(self.db_path)
+        self.assertIn("in the last 24.0h", self._sent_message())
+
+    def test_losing_the_claim_skips_the_send(self) -> None:
+        self._seed_failures(5)
+        with patch.object(jobs_runtime_module, "claim_notify_state", return_value=False):
+            maybe_notify_youtube_failures(self.db_path)
+        self.send_mock.assert_not_called()
+
+    def test_notify_state_claim_is_single_winner(self) -> None:
         init_db(self.db_path)
-        set_notify_state(self.db_path, "k", "v1")
-        set_notify_state(self.db_path, "k", "v2")
+        self.assertTrue(claim_notify_state(self.db_path, "k", None, "v1"))
+        self.assertFalse(claim_notify_state(self.db_path, "k", None, "v2"))
+        self.assertFalse(claim_notify_state(self.db_path, "k", "stale", "v3"))
+        self.assertTrue(claim_notify_state(self.db_path, "k", "v1", "v2"))
         self.assertEqual(get_notify_state(self.db_path, "k"), "v2")
 
 

--- a/api/worker/worker.py
+++ b/api/worker/worker.py
@@ -19,7 +19,7 @@ from api.db import (
     set_job_progress,
     set_job_status,
 )
-from api.routes.jobs_runtime import failure_code_for, log_event
+from api.routes.jobs_runtime import failure_code_for, log_event, maybe_notify_youtube_failures
 from api.utils import (
     analysis_path_for,
     audio_path_for,
@@ -233,6 +233,7 @@ def run_worker_loop() -> None:
     (STORAGE_ROOT / "logs").mkdir(parents=True, exist_ok=True)
 
     while True:
+        maybe_notify_youtube_failures(DB_PATH)
         job = claim_next_job(DB_PATH)
         if not job:
             time.sleep(1.0)


### PR DESCRIPTION
Replaces per-failure YT ntfy pings with a batched notifier: the worker loop periodically counts jobs stuck in `failed` with block-like errors (403, bot-check, 429, unavailable, network) and sends one summary ping once 5+ (testing this number) pile up since the last alert, at most once per 6 hours. Failures the user retries to success drop out of the count, so transient 403 spurts no longer notify at all.